### PR TITLE
fix: disable Git LFS for nightly runs to unblock actions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,4 @@
-nightly_reports/*.json filter=lfs diff=lfs merge=lfs -text
-nightly_reports/*.html filter=lfs diff=lfs merge=lfs -text
-docs/nightly_reports/*.json filter=lfs diff=lfs merge=lfs -text
-analysis/*.json filter=lfs diff=lfs merge=lfs -text
-analysis/*.md filter=lfs diff=lfs merge=lfs -text
-latest_consolidated_report.json filter=lfs diff=lfs merge=lfs -text
+# Git LFS was previously used for nightly_reports/, analysis/, and
+# latest_consolidated_report.json. LFS storage/bandwidth quota was exhausted,
+# so new files are stored as regular git blobs. Existing LFS pointers in
+# history are left untouched. Do not re-add LFS patterns without budget.

--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -8,6 +8,9 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # LFS quota is exhausted; skip smudge so checkouts don't burn bandwidth
+  # on pointer resolution. Old LFS pointers remain in history as-is.
+  GIT_LFS_SKIP_SMUDGE: 1
 
 permissions:
   contents: write
@@ -27,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Need full history for cache file
-          lfs: true
+          lfs: false
 
       - name: Set date output
         id: set_date
@@ -132,7 +135,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          lfs: true
+          lfs: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -189,10 +192,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          lfs: true
-
-      - name: Set up Git LFS
-        run: git lfs install
+          lfs: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -282,12 +282,8 @@ jobs:
 
           TODAY="${{ needs.fetch_and_scan.outputs.scan_date }}"
 
-          # Ensure LFS is tracking patterns from .gitattributes
-          git lfs track "nightly_reports/*.json" "nightly_reports/*.html" \
-            "nightly_reports/threat_intel/*.json" "nightly_reports/threat_intel/*.csv" \
-            "docs/nightly_reports/*.json" "analysis/*.json" "analysis/*.md" \
-            "latest_consolidated_report.json" "latest_threat_intel.json"
-          git add .gitattributes
+          # LFS is intentionally disabled here (quota exhausted). New files
+          # go straight into regular git. See .gitattributes for rationale.
 
           # Add today's generated files only (avoid re-staging old large files)
           git add latest_consolidated_report.json

--- a/bin/build.py
+++ b/bin/build.py
@@ -31,6 +31,20 @@ TECHNIQUES_DIR = ROOT_DIR / "techniques"
 
 OUTPUT_DIR.mkdir(exist_ok=True)
 
+def is_lfs_pointer(file_path: Path) -> bool:
+    """Detect git-lfs pointer files left over from the pre-quota era.
+
+    LFS smudge is disabled in CI (quota exhausted), so unresolved pointers
+    sit on disk as ~130-byte text files. Treat them as absent for build.
+    """
+    try:
+        if file_path.stat().st_size > 1024:
+            return False
+        with open(file_path, 'rb') as f:
+            return f.read(40).startswith(b"version https://git-lfs.github.com/spec/")
+    except OSError:
+        return False
+
 def log(msg):
     """Flush output immediately for CI visibility"""
     print(msg, flush=True)
@@ -92,7 +106,10 @@ def get_recent_report_files(limit: int = 10) -> List[Path]:
     if not REPORTS_DIR.exists():
         return []
     
-    json_files = list(REPORTS_DIR.glob("clickgrab_report_*.json"))
+    json_files = [
+        f for f in REPORTS_DIR.glob("clickgrab_report_*.json")
+        if not is_lfs_pointer(f)
+    ]
     # Sort by mtime descending
     json_files.sort(key=lambda f: f.stat().st_mtime, reverse=True)
     
@@ -518,8 +535,9 @@ def build_analysis_page(env: Environment, base_url: str):
     
     # Get recent blog data files
     if ANALYSIS_DIR.exists():
-        blog_files = sorted(ANALYSIS_DIR.glob("blog_data_*.json"), reverse=True)[:10]
-        
+        candidates = sorted(ANALYSIS_DIR.glob("blog_data_*.json"), reverse=True)
+        blog_files = [f for f in candidates if not is_lfs_pointer(f)][:10]
+
         for blog_file in blog_files:
             try:
                 with open(blog_file, 'r', encoding='utf-8') as f:
@@ -546,19 +564,20 @@ def build_blog_post_pages(env: Environment, base_url: str):
     if not ANALYSIS_DIR.exists():
         return
     
-    blog_files = sorted(ANALYSIS_DIR.glob("blog_data_*.json"), reverse=True)[:1]
-    
+    candidates = sorted(ANALYSIS_DIR.glob("blog_data_*.json"), reverse=True)
+    blog_files = [f for f in candidates if not is_lfs_pointer(f)][:1]
+
     for blog_file in blog_files:
         try:
             with open(blog_file, 'r', encoding='utf-8') as f:
                 blog_data = json.load(f)
-            
+
             date_str = blog_data.get('date')
             if not date_str:
                 continue
-            
+
             md_file = ANALYSIS_DIR / f"report_{date_str}.md"
-            if md_file.exists():
+            if md_file.exists() and not is_lfs_pointer(md_file):
                 content = md_file.read_text(encoding='utf-8')
                 
                 # Truncate very large files to avoid slow markdown parsing


### PR DESCRIPTION
## Summary

Git LFS quota was exhausted (~1.5 GB stored vs 1 GB free tier), causing every nightly run to fail — either on checkout (bandwidth) or on push (storage). This PR stops the bleeding without rewriting history or deleting any files.

- **`.gitattributes`** — cleared LFS filter patterns. New files for `nightly_reports/`, `analysis/`, `latest_consolidated_report.json`, etc. go to regular git. File sizes are well under the 100 MB blob limit.
- **`.github/workflows/nightly_run.yml`** — set `GIT_LFS_SKIP_SMUDGE=1` globally, flipped all three checkouts to `lfs: false`, removed the `git lfs install` step and the `git lfs track …` call in the commit step. No more LFS bandwidth or storage consumption per run.
- **`bin/build.py`** — added `is_lfs_pointer()` and filter the recent-reports selector, analysis page, and blog-post pages so the build keeps working while plain-git files accumulate. Without this, the build would try to `json.load()` 130-byte pointer files and crash.

## What this does not do

- Does not rewrite history — old LFS pointer commits stay as-is.
- Does not reclaim the ~1.5 GB of LFS storage already on the account. That requires `git filter-repo` + a GitHub Support ticket (or delete/recreate the repo). The quota number stays "over" cosmetically but nothing blocks runs because nothing uses LFS anymore.

## Expected behavior after merge

The next nightly run (or a `workflow_dispatch`) should be green. The `/reports` archive and `/analysis` pages will be sparse at first — only showing data from runs after this merges — and refill naturally as new plain-git files land:

- 1 run → 1 report / 1 analysis entry
- 5 runs → full report-detail pages populated (limit 5)
- 10 runs → full analysis page populated (limit 10)
- 30 runs → full reports archive list populated (limit 30)

## Test plan

- [ ] Merge to `main`
- [ ] Trigger the "Nightly ClickGrab Analysis" workflow via `workflow_dispatch`
- [ ] Confirm all three jobs (fetch_and_scan, analyze_and_blog, build_and_publish) pass
- [ ] Confirm the commit+push step succeeds without LFS errors
- [ ] Spot-check the newly committed `nightly_reports/clickgrab_report_<today>.json` is a plain JSON (not a 130-byte LFS pointer)
- [ ] Visit the rendered site and confirm today's report page renders

https://claude.ai/code/session_016rnLpyj95CNeArZgaLZ8mK

---
_Generated by [Claude Code](https://claude.ai/code/session_016rnLpyj95CNeArZgaLZ8mK)_