### PR TITLE
fix: trim nightly artifacts to fit under GitHub's 100 MB limit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,13 @@
 # latest_consolidated_report.json. LFS storage/bandwidth quota was exhausted,
 # so new files are stored as regular git blobs. Existing LFS pointers in
 # history are left untouched. Do not re-add LFS patterns without budget.
+#
+# To keep nightly artifacts under GitHub's 100 MB hard limit:
+#   - clickgrab.py omits RawHTML from the JSON report by default
+#     (use --include-raw-html for offline forensic archives)
+#   - bin/analyze.py drops analysis_data from blog_data_*.json
+#     (templates only render the stats block)
+#   - bin/analyze.py caps report_*.md at ~250 KB
+#   - threat_intel/*.json caps individual snippet values at 8 KB
+# Full uncompressed scan output is uploaded as a workflow artifact
+# (7-day retention) for anyone who wants the raw forensic data.

--- a/bin/analyze.py
+++ b/bin/analyze.py
@@ -548,33 +548,54 @@ class ReportGenerator:
                 "obfuscation_score": obfuscation_analysis.get("obfuscation_score", 0),
                 "attack_sophistication": flow_analysis.get("attack_sophistication", 0)
             },
+            # Templates only render the `stats` block above. The full analysis
+            # dicts (obfuscation/flow/keyword/url_patterns) inflated this file
+            # to 100+ MB; the markdown report carries the human-readable form,
+            # and downstream consumers can recompute from the main scan JSON.
+            # Domain counts kept — small and useful for at-a-glance summaries.
             "analysis_data": {
-                "obfuscation_analysis": obfuscation_analysis,
-                "flow_analysis": flow_analysis,
-                "keyword_analysis": keyword_analysis,
                 "domain_counts": Counter(threat_data.domains).most_common(10),
-                "url_patterns": PatternAnalyzer.analyze_url_patterns(threat_data.urls)
             }
         }
         
         return blog_data
     
-    def generate_report(self, threat_data: ThreatIntelligence, report_date: str, 
+    def generate_report(self, threat_data: ThreatIntelligence, report_date: str,
                        total_sites: int) -> Path:
         """Generate a comprehensive markdown report."""
         output_file = self.output_dir / f"report_{report_date}.md"
-        
+
+        # build.py truncates at 50K chars before rendering, so capping here at
+        # 250K keeps room for the unrendered tail in archives without shipping
+        # 50+ MB of inlined match context that no downstream reads.
+        MAX_REPORT_BYTES = 250_000
+
+        import io
+        buf = io.StringIO()
+        self._write_header(buf, report_date)
+        self._write_statistics(buf, threat_data, total_sites)
+        self._write_domain_analysis(buf, threat_data)
+        self._write_pattern_analysis(buf, threat_data)
+        self._write_keyword_analysis(buf, threat_data)
+        self._write_obfuscation_analysis(buf, threat_data)
+        self._write_clipboard_analysis(buf, threat_data)
+        self._write_attack_flow_analysis(buf, threat_data)
+        self._write_attack_reconstruction(buf, threat_data)
+        self._write_conclusion(buf, threat_data, total_sites)
+
+        content = buf.getvalue()
+        if len(content) > MAX_REPORT_BYTES:
+            cutoff = content.rfind('\n## ', 0, MAX_REPORT_BYTES)
+            if cutoff == -1:
+                cutoff = MAX_REPORT_BYTES
+            content = content[:cutoff] + (
+                "\n\n---\n*Report truncated for storage. "
+                "Full per-site detail is available in the scan JSON under nightly_reports/.*\n"
+            )
+            logger.info(f"Truncated markdown report to {len(content):,} bytes")
+
         with open(output_file, "w", encoding='utf-8') as f:
-            self._write_header(f, report_date)
-            self._write_statistics(f, threat_data, total_sites)
-            self._write_domain_analysis(f, threat_data)
-            self._write_pattern_analysis(f, threat_data)
-            self._write_keyword_analysis(f, threat_data)
-            self._write_obfuscation_analysis(f, threat_data)
-            self._write_clipboard_analysis(f, threat_data)
-            self._write_attack_flow_analysis(f, threat_data)
-            self._write_attack_reconstruction(f, threat_data)
-            self._write_conclusion(f, threat_data, total_sites)
+            f.write(content)
         
         # Also generate structured blog post data
         blog_data = self.generate_blog_post_data(threat_data, report_date, total_sites)

--- a/clickgrab.py
+++ b/clickgrab.py
@@ -1503,16 +1503,21 @@ def generate_json_report(results: List[AnalysisResult], config: ClickGrabConfig)
     report_name = f"clickgrab_report_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
     report_path = os.path.join(output_dir, report_name)
     
-    # Write JSON to file with additional info
+    # RawHTML is excluded by default — it's ~1-2 MB per site, the static site
+    # never reads it, and Streamlit reads it from in-memory results, not disk.
+    # Pass --include-raw-html to keep it (e.g. for offline forensic archives).
+    dump_kwargs = {"exclude_none": True, "indent": 2}
+    if not config.include_raw_html:
+        dump_kwargs["exclude"] = {"sites": {"__all__": {"RawHTML"}}}
+
     with open(report_path, 'w', encoding='utf-8') as f:
-        json_data = report.model_dump_json(exclude_none=True, indent=2)
+        json_data = report.model_dump_json(**dump_kwargs)
         f.write(json_data)
-    
-    # Also create a latest copy for easy access
+
     latest_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "latest_consolidated_report.json")
     with open(latest_path, 'w', encoding='utf-8') as f:
         f.write(json_data)
-    
+
     return report_path
 
 
@@ -1630,6 +1635,15 @@ def generate_threat_intel_exports(results: List[AnalysisResult], config: ClickGr
     date_str = datetime.now().strftime("%Y-%m-%d")
     paths = []
 
+    # Cap individual snippet length so a single obfuscated JS blob can't
+    # singlehandedly push these exports past GitHub's 50 MB warning line.
+    MAX_VALUE_LEN = 8192
+
+    def _trim(value):
+        if isinstance(value, str) and len(value) > MAX_VALUE_LEN:
+            return value[:MAX_VALUE_LEN] + f"\n…[truncated, {len(value) - MAX_VALUE_LEN} more chars]"
+        return value
+
     # --- Clipboard Commands ---
     clipboard_rows = []
     for r in results:
@@ -1639,14 +1653,14 @@ def generate_threat_intel_exports(results: List[AnalysisResult], config: ClickGr
                 "source_url": url,
                 "threat_score": r.ThreatScore,
                 "category": "Clipboard Command",
-                "value": cmd,
+                "value": _trim(cmd),
             })
         for snip in r.ClipboardManipulation:
             clipboard_rows.append({
                 "source_url": url,
                 "threat_score": r.ThreatScore,
                 "category": "Clipboard Manipulation JS",
-                "value": snip,
+                "value": _trim(snip),
             })
 
     if clipboard_rows:
@@ -1684,7 +1698,7 @@ def generate_threat_intel_exports(results: List[AnalysisResult], config: ClickGr
                     "source_url": url,
                     "threat_score": r.ThreatScore,
                     "category": label,
-                    "value": value,
+                    "value": _trim(value),
                 })
 
     if cradle_rows:
@@ -1717,7 +1731,7 @@ def generate_threat_intel_exports(results: List[AnalysisResult], config: ClickGr
                     "source_url": url,
                     "threat_score": r.ThreatScore,
                     "category": label,
-                    "value": item,
+                    "value": _trim(item),
                 })
 
     if lure_rows:
@@ -1800,7 +1814,8 @@ def parse_arguments() -> ClickGrabConfig:
     parser.add_argument("--clickfix-gist", action="store_true", help="Pull domains from the public ClickFix gist feed")
     parser.add_argument("--clickfix-gist-id", default=None, help=f"Override GitHub Gist ID for the ClickFix feed (default: {DEFAULT_CLICKFIX_GIST_ID})")
     parser.add_argument("--export-intel", action="store_true", help="Generate focused threat intel exports (clipboard commands, download cradles, lure variants)")
-    
+    parser.add_argument("--include-raw-html", action="store_true", help="Include full RawHTML in JSON report (off by default; reports run ~150x larger with it on)")
+
     args = parser.parse_args()
     
     # Convert args to dict and create Pydantic model

--- a/models.py
+++ b/models.py
@@ -1292,6 +1292,7 @@ class ClickGrabConfig(BaseModel):
     otx: bool = Field(False, description="Download and analyze URLs from AlienVault OTX")
     days: int = Field(30, description="Number of days to look back in AlienVault OTX")
     export_intel: bool = Field(False, description="Generate focused threat intel exports (clipboard commands, download cradles, lure variants)")
+    include_raw_html: bool = Field(False, description="Include full RawHTML in JSON report. Off by default — adds ~1-2 MB per scanned site and the static site never reads it. Streamlit live scans get RawHTML from in-memory results regardless.")
     clickfix_gist: bool = Field(False, description="Download and analyze domains from the ClickFix gist feed")
     clickfix_gist_id: Optional[str] = Field(
         None,


### PR DESCRIPTION
## Summary

Tonight's nightly run pushed a 154 MB scan report and a 139 MB blog data file — both blocked by GitHub's 100 MB hard limit (LFS quota was already exhausted). This trims the on-disk output without changing what the static site renders.

- **`clickgrab.py`**: omit `RawHTML` from JSON report by default (~99% size drop). New `--include-raw-html` flag preserves it for offline forensic archives. Streamlit live scans are unaffected — they read `RawHTML` from in-memory results, never from disk.
- **`bin/analyze.py`**: drop unused `analysis_data` dict from `blog_data_*.json`. Templates only render the `stats` block (`templates/analysis.html`, `templates/blog_post.html`); `domain_counts` kept for at-a-glance summaries.
- **`bin/analyze.py`**: cap markdown report at ~250 KB at write time. `build.py` already truncates to 50 KB before rendering, so the rest was dead weight.
- **`threat_intel/*.json`**: cap individual snippet `value` strings at 8 KB so one obfuscated JS blob can't blow past the 50 MB warning line.

Full uncompressed scan output is still produced and uploaded as a workflow artifact (7-day retention) for anyone who wants the raw forensic data.

### Sanity check

```
1 site with 1 MB RawHTML →
  slim: 1,091 bytes
  full: 1,001,104 bytes
include_raw_html default: False
```

A 100-site scan that previously produced ~154 MB should now produce ~5–10 MB.

## Test plan

- [ ] Trigger `Nightly ClickGrab Analysis` workflow manually (`workflow_dispatch`)
- [ ] Verify `nightly_reports/clickgrab_report_*.json` is < 20 MB
- [ ] Verify `analysis/blog_data_*.json` is < 100 KB
- [ ] Verify `analysis/report_*.md` is < 300 KB
- [ ] Verify `nightly_reports/threat_intel/*.json` are all < 50 MB
- [ ] Verify the commit-and-push step succeeds
- [ ] Spot-check the rendered site (`docs/analysis.html`, `docs/reports/*.html`) looks identical to prior runs
- [ ] Confirm Streamlit live scan still shows raw HTML in the expander

https://claude.ai/code/session_018ZxHuA68cjuSvC6NCbQdoQ

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZxHuA68cjuSvC6NCbQdoQ)_