### PR TITLE
Fix Threat Intel Exports + Live Scan stability; dark hacker-terminal redesign

### DIFF
--- a/clickgrab.py
+++ b/clickgrab.py
@@ -123,6 +123,37 @@ def sanitize_url(url: str) -> str:
     return sanitized
 
 
+def _read_text_capped(response, max_bytes: int = 3_000_000, deadline: Optional[float] = None) -> str:
+    """Read a streamed response body with a hard byte cap AND wall-clock deadline.
+
+    requests' read timeout only bounds the gap *between* chunks, so a host that
+    trickles one byte just under each read-timeout boundary can keep a single GET
+    alive indefinitely. Reading via ``iter_content`` against a ``time.monotonic``
+    deadline bounds total transfer time regardless of how the server behaves.
+    """
+    import time as _t
+    chunks = []
+    total = 0
+    try:
+        for chunk in response.iter_content(8192):
+            if chunk:
+                chunks.append(chunk)
+                total += len(chunk)
+            if total >= max_bytes:
+                break
+            if deadline is not None and _t.monotonic() > deadline:
+                logger.debug("Body read hit wall-clock deadline; returning partial content.")
+                break
+    except requests.RequestException as exc:
+        logger.debug(f"Stream read interrupted: {exc}")
+    raw = b"".join(chunks)
+    enc = response.encoding or "utf-8"
+    try:
+        return raw.decode(enc, errors="ignore")
+    except (LookupError, TypeError):
+        return raw.decode("utf-8", errors="ignore")
+
+
 def get_html_content(url: str, max_redirects: int = 2) -> Optional[str]:
     """Fetch HTML content from a URL.
     
@@ -151,19 +182,27 @@ def get_html_content(url: str, max_redirects: int = 2) -> Optional[str]:
         }
         
         # Create a session to handle redirects
+        import time as _time
+        body_deadline = _time.monotonic() + 20  # total wall-clock cap for this fetch
         with requests.Session() as session:
             session.max_redirects = max_redirects
-            response = session.get(url, headers=headers, timeout=10, allow_redirects=True, verify=False)
+            # (connect, read) timeouts bound each socket op; stream=True + a capped,
+            # deadline-bounded body read bounds TOTAL transfer time, so a host that
+            # trickles bytes forever can't freeze a scan (slowloris-style C2).
+            response = session.get(
+                url, headers=headers, timeout=(5, 15),
+                allow_redirects=True, verify=False, stream=True,
+            )
             response.raise_for_status()
-            
+
             # Log redirect chain if any redirects occurred
             if len(response.history) > 0:
                 logger.info(f"Redirect chain for {url}:")
                 for r in response.history:
                     logger.info(f"  {r.status_code}: {r.url}")
                 logger.info(f"  Final URL: {response.url}")
-            
-            return response.text
+
+            return _read_text_capped(response, max_bytes=3_000_000, deadline=body_deadline)
     except requests.RequestException as e:
         logger.error(f"Error fetching URL {url}: {e}")
         return None
@@ -673,21 +712,31 @@ def fetch_and_analyze_external_js(base_url: str, html_content: str) -> List[str]
         
         if not external_scripts:
             return results
-        
-        # Limit to first 5 external scripts to avoid slowdown
-        for script_url in external_scripts[:5]:
+
+        # Limit to first few external scripts AND a wall-clock budget so this
+        # stage can never dominate a scan (some hosts trickle bytes forever).
+        import time as _time
+        _budget_start = _time.monotonic()
+        for script_url in external_scripts[:4]:
+            if _time.monotonic() - _budget_start > 12:
+                logger.debug("External JS analysis budget (12s) exceeded; stopping early.")
+                break
             try:
                 logger.debug(f"Fetching external JS for obfuscation analysis: {script_url}")
                 response = requests.get(
-                    script_url, 
-                    timeout=5, 
+                    script_url,
+                    timeout=(4, 6),
                     verify=False,
+                    stream=True,
                     headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
                 )
                 response.raise_for_status()
-                
-                # Only analyze first 50KB to avoid huge files
-                js_content = response.text[:50000]
+
+                # Only analyze first 50KB, bounded by the remaining stage budget so a
+                # trickling host can't stall mid-download.
+                js_content = _read_text_capped(
+                    response, max_bytes=50000, deadline=_budget_start + 12
+                )
                 
                 # Run obfuscation detection on the actual JS content
                 obfuscation_hits = extractors.extract_heavy_obfuscation(js_content)

--- a/docs/analysis.html
+++ b/docs/analysis.html
@@ -5,30 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ClickGrab - Threat Intelligence Analysis</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <style>
     /* Blog-specific styles */
     .analysis-hero {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: linear-gradient(135deg, var(--surface) 0%, var(--surface-3) 100%);
+        color: var(--text);
         text-align: center;
         padding: 4rem 2rem;
         border-radius: var(--border-radius);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
         margin-bottom: 3rem;
-        box-shadow: var(--shadow-lg);
+        box-shadow: var(--shadow);
         position: relative;
         overflow: hidden;
     }
-    
+
     .analysis-hero::before {
         content: '';
         position: absolute;
@@ -36,205 +35,217 @@
         left: 0;
         right: 0;
         bottom: 0;
-        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="20" cy="20" r="2" fill="rgba(255,255,255,0.1)"/><circle cx="80" cy="40" r="1.5" fill="rgba(255,255,255,0.1)"/><circle cx="40" cy="60" r="1" fill="rgba(255,255,255,0.1)"/><circle cx="70" cy="80" r="2.5" fill="rgba(255,255,255,0.1)"/></svg>') repeat;
+        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="20" cy="20" r="2" fill="rgba(0,255,136,0.08)"/><circle cx="80" cy="40" r="1.5" fill="rgba(0,255,136,0.08)"/><circle cx="40" cy="60" r="1" fill="rgba(0,255,136,0.08)"/><circle cx="70" cy="80" r="2.5" fill="rgba(0,255,136,0.08)"/></svg>') repeat;
         pointer-events: none;
     }
-    
+
     .analysis-hero .content {
         position: relative;
         z-index: 1;
     }
-    
+
     .analysis-hero h1 {
         font-size: 3rem;
         margin-bottom: 1rem;
         border-bottom: none;
-        color: white;
-        background: linear-gradient(45deg, #fff, #f0f8ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 2px;
+        color: var(--accent);
     }
-    
+
     .analysis-hero p {
         font-size: 1.3rem;
         opacity: 1;
         max-width: 600px;
         margin: 0 auto;
-        color: rgba(255, 255, 255, 0.95);
-        text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+        color: var(--text-soft);
         font-weight: 400;
     }
-    
+
     /* Key Insights Section */
     .key-insights {
-        background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
-        border-radius: 16px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 2rem;
         margin-bottom: 3rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border: 1px solid #e2e8f0;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
     }
-    
+
     .insights-header {
         display: flex;
         align-items: center;
         gap: 1rem;
         margin-bottom: 1.5rem;
     }
-    
+
     .insights-icon {
         width: 48px;
         height: 48px;
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        border-radius: 12px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         display: flex;
         align-items: center;
         justify-content: center;
         font-size: 24px;
     }
-    
+
     .insights-title {
         font-size: 1.75rem;
-        font-weight: 700;
-        color: var(--text-color);
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
     }
-    
+
     .insights-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
         gap: 1.5rem;
     }
-    
+
     .insight-item {
         text-align: center;
         padding: 1.5rem;
-        background: white;
-        border-radius: 12px;
-        border: 1px solid #e2e8f0;
-        transition: all 0.3s ease;
+        background: var(--surface-2);
+        border-radius: var(--border-radius);
+        border: 1px solid var(--border);
+        transition: all 0.18s ease;
     }
-    
+
     .insight-item:hover {
         transform: translateY(-3px);
-        box-shadow: 0 8px 20px rgba(0,0,0,0.1);
+        border-color: var(--accent);
+        box-shadow: var(--shadow);
     }
-    
+
     .insight-value {
         font-size: 2.5rem;
+        font-family: var(--font-mono);
         font-weight: 700;
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
         display: block;
         margin-bottom: 0.5rem;
     }
-    
+
     .insight-label {
         font-size: 0.9rem;
-        color: var(--text-light);
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        color: var(--muted);
         font-weight: 500;
     }
-    
+
     /* Search and Filter Bar */
     .analysis-controls {
-        background: white;
-        border-radius: 16px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 1.5rem;
         margin-bottom: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border: 1px solid #e2e8f0;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
     }
-    
+
     .controls-row {
         display: flex;
         gap: 1rem;
         align-items: center;
         flex-wrap: wrap;
     }
-    
+
     .search-box {
         flex: 2;
         position: relative;
         min-width: 300px;
     }
-    
+
     .search-input {
         width: 100%;
         padding: 0.75rem 1rem 0.75rem 3rem;
-        border: 2px solid #e2e8f0;
-        border-radius: 10px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        color: var(--text);
         font-size: 1rem;
-        transition: all 0.3s ease;
+        transition: all 0.18s ease;
     }
-    
+
+    .search-input::placeholder {
+        color: var(--muted);
+    }
+
     .search-input:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
-    
+
     .search-icon {
         position: absolute;
         left: 1rem;
         top: 50%;
         transform: translateY(-50%);
-        color: #94a3b8;
+        color: var(--muted);
     }
-    
+
     .filter-chips {
         display: flex;
         gap: 0.5rem;
         flex-wrap: wrap;
         flex: 1;
     }
-    
+
     .filter-chip {
         padding: 0.5rem 1rem;
-        background: #f1f5f9;
-        border: 2px solid transparent;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
         border-radius: 20px;
+        font-family: var(--font-mono);
         font-size: 0.9rem;
         font-weight: 500;
         cursor: pointer;
-        transition: all 0.3s ease;
-        color: var(--text-light);
+        transition: all 0.18s ease;
+        color: var(--text-soft);
     }
-    
+
     .filter-chip:hover {
-        background: #e2e8f0;
+        background: var(--surface-3);
+        border-color: var(--accent);
     }
-    
+
     .filter-chip.active {
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        color: white;
-        border-color: transparent;
+        background: var(--accent);
+        color: var(--bg);
+        border-color: var(--accent);
     }
-    
+
     .blog-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
         gap: 2rem;
         margin-bottom: 3rem;
     }
-    
+
     .blog-card {
-        background: white;
-        border-radius: 12px;
-        box-shadow: 0 8px 32px rgba(0,0,0,0.12);
+        background: var(--surface);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
         overflow: hidden;
-        transition: all 0.3s ease;
-        border: 1px solid rgba(255,255,255,0.2);
+        transition: all 0.18s ease;
+        border: 1px solid var(--border);
         position: relative;
         opacity: 0;
         animation: fadeInUp 0.6s ease forwards;
     }
-    
+
     .blog-card:nth-child(1) { animation-delay: 0.1s; }
     .blog-card:nth-child(2) { animation-delay: 0.2s; }
     .blog-card:nth-child(3) { animation-delay: 0.3s; }
-    
+
     @keyframes fadeInUp {
         from {
             opacity: 0;
@@ -245,189 +256,214 @@
             transform: translateY(0);
         }
     }
-    
+
     .blog-card:hover {
         transform: translateY(-8px);
-        box-shadow: 0 20px 40px rgba(0,0,0,0.15);
+        border-color: var(--accent);
+        box-shadow: var(--shadow);
     }
-    
+
     .blog-card::before {
         content: '';
         position: absolute;
         top: 0;
         left: 0;
         right: 0;
-        height: 4px;
-        background: linear-gradient(90deg, var(--primary-color), var(--accent-color));
+        height: 3px;
+        background: var(--accent);
+        z-index: 1;
     }
-    
+
     .blog-header {
-        background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+        background: var(--surface-2);
         padding: 1.5rem;
-        border-bottom: 1px solid #e2e8f0;
+        border-bottom: 1px solid var(--border);
     }
-    
+
     .blog-meta {
         display: flex;
         align-items: center;
         gap: 1rem;
         margin-bottom: 1rem;
         font-size: 0.9rem;
-        color: var(--text-light);
+        color: var(--muted);
     }
-    
+
     .blog-date {
-        background: var(--primary-color);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent);
+        font-family: var(--font-mono);
         padding: 0.25rem 0.75rem;
         border-radius: 20px;
         font-weight: 500;
         font-size: 0.8rem;
     }
-    
+
     .blog-category {
-        background: linear-gradient(45deg, #ff6b6b, #ee5a24);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent3);
+        color: var(--accent3);
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
         padding: 0.25rem 0.75rem;
         border-radius: 20px;
         font-weight: 500;
         font-size: 0.8rem;
     }
-    
+
     .blog-title {
         font-size: 1.5rem;
-        font-weight: 700;
-        color: var(--text-color);
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin-bottom: 0.5rem;
         line-height: 1.3;
     }
-    
+
     .blog-excerpt {
-        color: var(--text-light);
+        color: var(--text-soft);
         line-height: 1.6;
         font-size: 1rem;
     }
-    
+
     .blog-content {
         padding: 1.5rem;
     }
-    
+
     .blog-stats {
         display: flex;
         gap: 1.5rem;
         margin-bottom: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .blog-stat {
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        color: white;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-top: 2px solid var(--accent);
+        color: var(--text);
         padding: 0.75rem 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         text-align: center;
         flex: 1;
         min-width: 80px;
     }
-    
+
     .blog-stat-number {
         font-size: 1.5rem;
+        font-family: var(--font-mono);
         font-weight: 700;
+        color: var(--accent);
         display: block;
     }
-    
+
     .blog-stat-label {
         font-size: 0.75rem;
-        opacity: 0.9;
+        font-family: var(--font-mono);
+        color: var(--muted);
         text-transform: uppercase;
         letter-spacing: 0.5px;
     }
-    
+
     .blog-tags {
         display: flex;
         flex-wrap: wrap;
         gap: 0.5rem;
         margin-bottom: 1.5rem;
     }
-    
+
     .blog-tag {
-        background: linear-gradient(45deg, #22c55e, #0891b2);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent);
+        font-family: var(--font-mono);
         padding: 0.25rem 0.75rem;
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
     }
-    
+
     .blog-actions {
         display: flex;
         gap: 1rem;
         align-items: center;
     }
-    
+
     .read-more {
-        background: linear-gradient(45deg, var(--primary-color), #4c51bf);
-        color: white;
+        background: var(--accent);
+        color: var(--bg);
         padding: 0.75rem 1.5rem;
-        border-radius: 25px;
+        border-radius: var(--border-radius);
         text-decoration: none;
+        font-family: var(--font-mono);
         font-weight: 600;
-        transition: all 0.3s ease;
-        box-shadow: 0 4px 15px rgba(37, 99, 235, 0.3);
+        letter-spacing: 0.5px;
+        transition: all 0.18s ease;
         flex: 1;
         text-align: center;
     }
-    
+
     .read-more:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(37, 99, 235, 0.4);
-        color: white;
+        background: var(--accent-dim);
+        color: var(--bg);
     }
-    
+
     .share-btn {
-        background: linear-gradient(45deg, #48bb78, #38a169);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent);
         padding: 0.75rem;
         border-radius: 50%;
         text-decoration: none;
-        transition: all 0.3s ease;
+        transition: all 0.18s ease;
         width: 45px;
         height: 45px;
         display: flex;
         align-items: center;
         justify-content: center;
     }
-    
+
     .share-btn:hover {
         transform: rotate(5deg) scale(1.1);
-        color: white;
+        border-color: var(--accent);
+        color: var(--accent);
     }
-    
+
     .featured-badge {
         position: absolute;
         top: 1rem;
         right: 1rem;
-        background: linear-gradient(45deg, #ffd700, #ffed4e);
-        color: #000;
+        background: var(--accent4);
+        color: var(--bg);
         padding: 0.5rem 1rem;
         border-radius: 20px;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
         font-size: 0.8rem;
         font-weight: 700;
         z-index: 2;
-        box-shadow: 0 4px 15px rgba(255, 215, 0, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     /* Newsletter Signup */
     .newsletter-section {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        border-radius: 16px;
+        background: linear-gradient(135deg, var(--surface) 0%, var(--surface-3) 100%);
+        border-radius: var(--border-radius);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
         padding: 3rem 2rem;
         margin: 3rem 0;
         text-align: center;
-        color: white;
+        color: var(--text);
         position: relative;
         overflow: hidden;
     }
-    
+
     .newsletter-section::before {
         content: '';
         position: absolute;
@@ -435,34 +471,36 @@
         right: -50%;
         width: 200%;
         height: 200%;
-        background: radial-gradient(circle, rgba(255,255,255,0.1) 0%, transparent 70%);
+        background: radial-gradient(circle, rgba(0,255,136,0.06) 0%, transparent 70%);
         animation: pulse 15s ease-in-out infinite;
     }
-    
+
     @keyframes pulse {
         0%, 100% { transform: scale(0.8); opacity: 0.5; }
         50% { transform: scale(1.2); opacity: 0.8; }
     }
-    
+
     .newsletter-content {
         position: relative;
         z-index: 1;
     }
-    
+
     .newsletter-title {
         font-size: 2rem;
         margin-bottom: 1rem;
-        font-weight: 700;
-        color: white;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent);
     }
-    
+
     .newsletter-desc {
         font-size: 1.1rem;
         margin-bottom: 2rem;
         opacity: 1;
-        color: white;
+        color: var(--text-soft);
     }
-    
+
     .newsletter-form {
         display: flex;
         gap: 1rem;
@@ -471,71 +509,72 @@
         flex-wrap: wrap;
         justify-content: center;
     }
-    
+
     .newsletter-input {
         flex: 1;
         min-width: 250px;
         padding: 0.75rem 1.5rem;
-        border: 2px solid rgba(255,255,255,0.3);
+        border: 1px solid var(--border);
         border-radius: 30px;
-        background: rgba(255,255,255,0.1);
-        color: white;
+        background: var(--surface-2);
+        color: var(--text);
         font-size: 1rem;
-        transition: all 0.3s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .newsletter-input::placeholder {
-        color: rgba(255,255,255,0.7);
+        color: var(--muted);
     }
-    
+
     .newsletter-input:focus {
         outline: none;
-        border-color: white;
-        background: rgba(255,255,255,0.2);
+        border-color: var(--accent);
+        background: var(--surface-3);
     }
-    
+
     .newsletter-submit {
         padding: 0.75rem 2rem;
-        background: white;
-        color: #0e7490;
+        background: var(--accent);
+        color: var(--bg);
         border: none;
         border-radius: 30px;
+        font-family: var(--font-mono);
         font-weight: 600;
+        letter-spacing: 0.5px;
         font-size: 1rem;
         cursor: pointer;
-        transition: all 0.3s ease;
-        box-shadow: 0 4px 15px rgba(0,0,0,0.2);
+        transition: all 0.18s ease;
     }
-    
+
     .newsletter-submit:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(0,0,0,0.3);
+        background: var(--accent-dim);
     }
-    
+
     .coming-soon {
         text-align: center;
         padding: 3rem 2rem;
-        background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
-        border-radius: 12px;
-        border: 2px dashed #cbd5e0;
+        background: var(--surface-2);
+        border-radius: var(--border-radius);
+        border: 2px dashed var(--border);
         margin-top: 2rem;
     }
-    
+
     .coming-soon h3 {
-        color: var(--text-light);
+        color: var(--text-soft);
         margin-bottom: 1rem;
     }
-    
+
     .coming-soon p {
-        color: var(--text-light);
+        color: var(--muted);
         font-style: italic;
     }
-    
+
     /* No Results */
     .no-results {
         text-align: center;
         padding: 3rem;
-        color: var(--text-light);
+        color: var(--muted);
         display: none;
     }
     
@@ -1157,7 +1196,7 @@
     <h2>About Our Analysis</h2>
     <p>Our threat intelligence analysis goes beyond automated reporting to provide deep technical insights into emerging attack patterns, obfuscation techniques, and defensive strategies. Each analysis includes:</p>
     
-    <ul style="margin-left: 2rem; color: var(--text-light);">
+    <ul style="margin-left: 2rem; color: var(--text-soft);">
         <li><strong>Technical Deep Dives:</strong> Detailed examination of attack methodologies and code analysis</li>
         <li><strong>Threat Actor Profiling:</strong> Infrastructure analysis and campaign attribution</li>
         <li><strong>Defensive Strategies:</strong> Actionable recommendations and detection rules</li>
@@ -1295,7 +1334,7 @@ function handleNewsletterSubmit(event) {
     // If they come back to the page with ?subscribed=true, show success
     if (window.location.search.includes('subscribed=true')) {
         submitBtn.textContent = '✓ Subscribed!';
-        submitBtn.style.background = '#22c55e';
+        submitBtn.style.background = 'var(--accent)';
         setTimeout(() => {
             submitBtn.textContent = 'Subscribe';
             submitBtn.style.background = '';

--- a/docs/analysis/clickgrab-analysis-2026-06-01.html
+++ b/docs/analysis/clickgrab-analysis-2026-06-01.html
@@ -5,35 +5,35 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Emerging ClickGrab Campaign: Advanced Analysis of 2026-06-01 Attack Patterns - ClickGrab Threat Intelligence</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <style>
     /* Blog post specific styles */
     .article-container {
         max-width: 900px;
         margin: 0 auto;
-        background: white;
-        border-radius: 12px;
-        box-shadow: var(--shadow-lg);
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
         overflow: hidden;
     }
-    
+
     .article-header {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: linear-gradient(135deg, var(--surface-2) 0%, var(--surface-3) 100%);
+        color: var(--text);
+        border-bottom: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
         padding: 3rem 2rem;
         text-align: center;
         position: relative;
     }
-    
+
     .article-header::before {
         content: '';
         position: absolute;
@@ -41,23 +41,26 @@
         left: 0;
         right: 0;
         bottom: 0;
-        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="20" cy="20" r="2" fill="rgba(255,255,255,0.1)"/><circle cx="80" cy="40" r="1.5" fill="rgba(255,255,255,0.1)"/><circle cx="40" cy="60" r="1" fill="rgba(255,255,255,0.1)"/><circle cx="70" cy="80" r="2.5" fill="rgba(255,255,255,0.1)"/></svg>') repeat;
+        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="20" cy="20" r="2" fill="rgba(0,255,136,0.12)"/><circle cx="80" cy="40" r="1.5" fill="rgba(0,255,136,0.12)"/><circle cx="40" cy="60" r="1" fill="rgba(0,255,136,0.12)"/><circle cx="70" cy="80" r="2.5" fill="rgba(0,255,136,0.12)"/></svg>') repeat;
         pointer-events: none;
     }
-    
+
     .article-header .content {
         position: relative;
         z-index: 1;
     }
-    
+
     .article-title {
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1.5px;
         font-size: 2.5rem;
         margin-bottom: 1rem;
         line-height: 1.2;
         border-bottom: none;
-        color: white;
+        color: var(--accent);
     }
-    
+
     .article-meta {
         display: flex;
         justify-content: center;
@@ -72,22 +75,26 @@
         margin-top: 1.25rem;
     }
     .hero-metric {
-        background: rgba(255,255,255,0.15);
-        border: 1px solid rgba(255,255,255,0.25);
-        color: white;
-        border-radius: 10px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
+        border-radius: var(--border-radius);
         padding: 0.75rem 1rem;
     }
-    .hero-metric .num { font-weight: 800; font-size: 1.4rem; display:block; }
-    .hero-metric .lbl { opacity: 0.95; font-size: 0.8rem; }
-    
+    .hero-metric .num { font-family: var(--font-mono); font-weight: 700; font-size: 1.4rem; display:block; color: var(--accent); }
+    .hero-metric .lbl { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 1px; color: var(--muted); font-size: 0.8rem; }
+
     .meta-item {
-        background: rgba(255,255,255,0.2);
+        font-family: var(--font-mono);
+        background: var(--surface);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
         padding: 0.5rem 1rem;
-        border-radius: 25px;
+        border-radius: 999px;
         font-size: 0.9rem;
     }
-    
+
     .article-content {
         padding: 3rem;
         line-height: 1.8;
@@ -97,189 +104,215 @@
     .toc-layout { display: grid; grid-template-columns: 1fr 260px; gap: 2rem; }
     .toc-sidebar {
         position: sticky; top: 100px; align-self: start; height: max-content;
-        background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 12px; padding: 1rem;
+        background: var(--surface-2); border: 1px solid var(--border);
+        border-left: 3px solid var(--accent); border-radius: var(--border-radius); padding: 1rem;
     }
-    .toc-title { font-weight: 700; margin: 0 0 0.5rem 0; font-size: 0.95rem; color: #334155; }
+    .toc-title { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 1px; font-weight: 700; margin: 0 0 0.5rem 0; font-size: 0.95rem; color: var(--accent); }
     .toc-list { list-style: none; margin: 0; padding: 0; }
     .toc-list li { margin: 0.25rem 0; }
-    .toc-link { color: #64748b; text-decoration: none; font-size: 0.9rem; }
-    .toc-link.active { color: #4f46e5; font-weight: 600; }
-    
+    .toc-link { color: var(--muted); text-decoration: none; font-size: 0.9rem; transition: color 0.18s ease; }
+    .toc-link:hover { color: var(--text-soft); }
+    .toc-link.active { color: var(--accent); font-weight: 600; }
+
     .article-content h2 {
-        color: var(--primary-color);
+        color: var(--accent);
         margin-top: 3rem;
         margin-bottom: 1.5rem;
         font-size: 1.8rem;
-        border-bottom: 2px solid var(--primary-color);
+        border-bottom: 1px solid var(--border);
         padding-bottom: 0.5rem;
     }
-    
+
     .article-content h3 {
-        color: var(--secondary-color);
+        color: var(--accent3);
         margin-top: 2rem;
         margin-bottom: 1rem;
         font-size: 1.4rem;
     }
-    
+
     .article-content h4 {
-        color: var(--text-color);
+        color: var(--text);
         margin-top: 1.5rem;
         margin-bottom: 0.75rem;
         font-size: 1.2rem;
     }
-    
+
     .article-content p {
         margin-bottom: 1.5rem;
-        color: var(--text-color);
+        color: var(--text-soft);
     }
-    
+
     .article-content ul, .article-content ol {
         margin-bottom: 1.5rem;
         padding-left: 2rem;
     }
-    
+
     .article-content li {
         margin-bottom: 0.5rem;
-        color: var(--text-color);
+        color: var(--text-soft);
     }
-    
+
     .article-content table {
         width: 100%;
         border-collapse: collapse;
         margin: 2rem 0;
-        background: #f8fafc;
-        border-radius: 8px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         overflow: hidden;
     }
-    
+
     .article-content th,
     .article-content td {
         padding: 1rem;
         text-align: left;
-        border-bottom: 1px solid #e2e8f0;
+        border-bottom: 1px solid var(--border);
+        color: var(--text-soft);
     }
-    
+
     .article-content th {
-        background: var(--primary-color);
-        color: white;
+        background: var(--surface-2);
+        color: var(--accent);
+        border-bottom: 2px solid var(--accent);
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         font-weight: 600;
     }
-    
+
     .article-content tr:hover {
-        background: #f1f5f9;
+        background: var(--highlight);
     }
-    
+
     .article-content pre {
-        background: #1a202c;
-        color: #e2e8f0;
+        background: #05050a;
+        color: var(--text-soft);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
         padding: 1.5rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         overflow-x: auto;
         margin: 1.5rem 0;
         line-height: 1.6;
+        font-family: var(--font-mono);
     }
-    
+
     .article-content code {
-        background: #f1f5f9;
-        color: #e53e3e;
+        background: var(--surface-3);
+        color: var(--accent3);
         padding: 0.25rem 0.5rem;
-        border-radius: 4px;
-        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+        border-radius: var(--border-radius);
+        font-family: var(--font-mono);
         font-size: 0.9em;
     }
-    
+
     .article-content pre code {
         background: none;
         color: inherit;
         padding: 0;
     }
-    
+
     .highlight-box {
-        background: linear-gradient(135deg, #fff5f5 0%, #fed7d7 100%);
-        border-left: 4px solid #e53e3e;
+        background: var(--surface-2);
+        border-left: 4px solid var(--accent2);
         padding: 1.5rem;
         margin: 2rem 0;
-        border-radius: 0 8px 8px 0;
+        border-radius: 0 var(--border-radius) var(--border-radius) 0;
+        color: var(--text-soft);
     }
-    
+
     .info-box {
-        background: linear-gradient(135deg, #ebf8ff 0%, #bee3f8 100%);
-        border-left: 4px solid var(--primary-color);
+        background: var(--surface-2);
+        border-left: 4px solid var(--accent3);
         padding: 1.5rem;
         margin: 2rem 0;
-        border-radius: 0 8px 8px 0;
+        border-radius: 0 var(--border-radius) var(--border-radius) 0;
+        color: var(--text-soft);
     }
-    
+
     .stats-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
         gap: 1.5rem;
         margin: 2rem 0;
     }
-    
+
     .stat-item {
-        background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         text-align: center;
     }
-    
+
     .stat-number {
+        font-family: var(--font-mono);
         font-size: 2rem;
         font-weight: 700;
+        color: var(--accent);
         display: block;
         margin-bottom: 0.5rem;
     }
-    
+
     .stat-label {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         font-size: 0.9rem;
-        opacity: 0.9;
+        color: var(--muted);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: var(--primary-color);
+        font-family: var(--font-mono);
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
         margin-bottom: 2rem;
-        transition: all 0.3s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .back-link:hover {
         transform: translateX(-5px);
+        color: var(--accent-dim);
     }
-    
+
     .article-footer {
-        background: #f8fafc;
+        background: var(--surface-2);
         padding: 2rem;
-        border-top: 1px solid #e2e8f0;
+        border-top: 1px solid var(--border);
         text-align: center;
+        color: var(--text-soft);
     }
-    
+
     .share-buttons {
         display: flex;
         justify-content: center;
         gap: 1rem;
         margin-top: 1rem;
     }
-    
+
     .share-btn-footer {
-        background: var(--primary-color);
-        color: white;
+        font-family: var(--font-mono);
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent);
         padding: 0.75rem 1.5rem;
-        border-radius: 25px;
+        border-radius: 999px;
         text-decoration: none;
         font-weight: 600;
-        transition: all 0.3s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .share-btn-footer:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(37, 99, 235, 0.3);
-        color: white;
+        border-color: var(--accent);
+        box-shadow: var(--shadow);
+        color: var(--accent);
     }
     
     @media (max-width: 768px) {

--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -1,280 +1,289 @@
-/* ClickGrab Styles */
+/* =========================================================================
+   ClickGrab — "Hunt in the Dark" design system
+   Hacker-terminal aesthetic, aligned with the BSides deck:
+   JetBrains Mono / Bebas Neue / Inter, near-black canvas, neon-green accent.
+   Fonts are loaded via <link> in base.html.
+   ========================================================================= */
+
 :root {
-    --primary-color: #0e7490;
-    --secondary-color: #0f766e;
-    --accent-color: #22c55e;
-    --text-color: #0f172a;
-    --text-light: #475569;
-    --background-color: #f4f8fb;
-    --danger-color: #ef4444;
-    --warning-color: #f59e0b;
-    --success-color: #22c55e;
-    --border-radius: 10px;
-    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-    --shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
-    --shadow-lg: 0 16px 36px rgba(15, 23, 42, 0.12);
+    /* --- Core palette (from the deck) --- */
+    --bg: #0a0a0f;
+    --surface: #0f0f1a;
+    --surface-2: #13131f;
+    --surface-3: #181826;
+    --border: #1e1e35;
+    --border-soft: #181830;
+
+    --accent: #00ff88;        /* neon green   */
+    --accent-dim: #00cc6a;
+    --accent2: #ff3366;       /* alert red    */
+    --accent3: #3d9eff;       /* info blue    */
+    --accent4: #ffcc00;       /* warning gold */
+
+    --text: #e8e8f0;
+    --text-soft: #c8c8d8;
+    --muted: #6b6b8a;
+    --highlight: rgba(0, 255, 136, 0.08);
+
+    /* --- Back-compat aliases (old templates reference these var names) --- */
+    --primary-color: var(--accent);
+    --secondary-color: var(--accent-dim);
+    --accent-color: var(--accent);
+    --text-color: var(--text);
+    --text-light: var(--muted);
+    --background-color: var(--bg);
+    --danger-color: var(--accent2);
+    --warning-color: var(--accent4);
+    --success-color: var(--accent);
+
+    --border-radius: 4px;
+    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.4);
+    --shadow: 0 12px 30px rgba(0, 0, 0, 0.5);
+    --shadow-lg: 0 20px 50px rgba(0, 0, 0, 0.6);
+
     --font-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    --font-display: 'Bebas Neue', 'Inter', sans-serif;
 }
 
-/* Base styles */
-* {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { scroll-behavior: smooth; }
 
 body {
     font-family: var(--font-sans);
-    line-height: 1.6;
-    color: var(--text-color);
-    background: linear-gradient(180deg, #f8fbfe 0%, var(--background-color) 280px);
+    line-height: 1.65;
+    color: var(--text);
+    background: var(--bg);
     font-size: 16px;
+    position: relative;
+    min-height: 100vh;
+    overflow-x: hidden;
+}
+
+/* Fixed background layers — grid + scanlines + glow, on every page */
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: -2;
+    background-image:
+        linear-gradient(rgba(0, 255, 136, 0.035) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 255, 136, 0.035) 1px, transparent 1px);
+    background-size: 42px 42px;
+    pointer-events: none;
+}
+body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: -2;
+    background:
+        radial-gradient(620px circle at 12% -5%, rgba(0, 255, 136, 0.10), transparent 60%),
+        radial-gradient(560px circle at 92% 0%, rgba(61, 158, 255, 0.10), transparent 55%);
+    pointer-events: none;
 }
 
 a {
-    color: var(--primary-color);
+    color: var(--accent);
     text-decoration: none;
-    transition: color 0.2s ease, transform 0.2s ease;
+    transition: color 0.18s ease, opacity 0.18s ease;
 }
-
-a:hover {
-    color: var(--secondary-color);
-}
+a:hover { color: var(--accent3); }
 
 .container {
-    width: 90%;
+    width: 92%;
     max-width: 1200px;
     margin: 0 auto;
     padding: 0 15px;
 }
 
-/* Typography */
+/* ---------------------------------------------------------------- Typography */
 h1, h2, h3, h4, h5, h6 {
     margin-bottom: 1rem;
-    color: var(--text-color);
+    color: var(--text);
     font-weight: 700;
-    line-height: 1.2;
+    line-height: 1.15;
+    letter-spacing: 0.3px;
 }
 
 h1 {
-    font-size: 2.25rem;
-    border-bottom: 2px solid var(--primary-color);
-    padding-bottom: 0.75rem;
-    margin-bottom: 1.5rem;
+    font-family: var(--font-display);
+    font-size: clamp(2.2rem, 4.4vw, 3.4rem);
+    letter-spacing: 3px;
+    font-weight: 400;
+    padding-bottom: 0.6rem;
+    margin-bottom: 1.4rem;
+    border-bottom: 1px solid var(--border);
+}
+h1::after {
+    content: '';
+    display: block;
+    width: 64px;
+    height: 2px;
+    margin-top: 0.6rem;
+    background: var(--accent);
+    box-shadow: 0 0 10px var(--accent);
 }
 
-h2 {
-    font-size: 1.875rem;
-    margin-top: 2rem;
-}
+h2 { font-size: 1.75rem; margin-top: 2rem; }
+h3 { font-size: 1.35rem; }
 
-h3 {
-    font-size: 1.5rem;
-}
+p { margin-bottom: 1.2rem; color: var(--text-soft); }
 
-p {
-    margin-bottom: 1.25rem;
-    color: var(--text-light);
-}
+code, pre, kbd, samp { font-family: var(--font-mono); }
 
-/* Header styles */
+/* selection */
+::selection { background: rgba(0, 255, 136, 0.25); color: #fff; }
+
+/* scrollbar */
+::-webkit-scrollbar { width: 11px; height: 11px; }
+::-webkit-scrollbar-track { background: var(--surface); }
+::-webkit-scrollbar-thumb { background: #25254a; border-radius: 6px; }
+::-webkit-scrollbar-thumb:hover { background: #32325f; }
+
+/* ----------------------------------------------------------------- Header */
 .site-header {
-    background-color: rgba(255, 255, 255, 0.92);
-    backdrop-filter: blur(10px);
-    box-shadow: 0 1px 0 rgba(15, 23, 42, 0.06);
-    border-bottom: 1px solid #e2e8f0;
-    padding: 1rem 0;
+    background: rgba(10, 10, 15, 0.82);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border);
+    padding: 0.9rem 0;
     position: sticky;
     top: 0;
     z-index: 100;
 }
-
 .site-header .container {
     display: flex;
     justify-content: space-between;
     align-items: center;
 }
-
 .logo a {
     display: flex;
     align-items: center;
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: var(--primary-color);
+    font-family: var(--font-display);
+    font-size: 1.6rem;
+    letter-spacing: 3px;
+    font-weight: 400;
+    color: var(--accent);
     text-decoration: none;
+    text-shadow: 0 0 18px rgba(0, 255, 136, 0.4);
+}
+.logo img { height: 38px; margin-right: 12px; }
+
+.text-logo {
+    font-family: var(--font-display);
+    font-size: 1.6rem;
+    letter-spacing: 3px;
+    font-weight: 400;
+    color: var(--accent);
+    text-shadow: 0 0 18px rgba(0, 255, 136, 0.4);
 }
 
-.logo img {
-    height: 40px;
-    margin-right: 12px;
-}
-
-.main-nav ul {
-    display: flex;
-    list-style: none;
-    gap: 1.5rem;
-}
-
+.main-nav ul { display: flex; list-style: none; gap: 0.4rem; }
 .main-nav a {
     text-decoration: none;
-    color: var(--text-color);
+    color: var(--text-soft);
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    letter-spacing: 1px;
+    text-transform: uppercase;
     font-weight: 500;
-    padding: 0.5rem 0.75rem;
+    padding: 0.5rem 0.85rem;
+    border: 1px solid transparent;
     border-radius: var(--border-radius);
-    transition: background-color 0.2s ease, color 0.2s ease;
+    transition: all 0.18s ease;
 }
-
 .main-nav a:hover {
-    background-color: #e0f2fe;
-    color: var(--primary-color);
+    color: var(--accent);
+    border-color: var(--border);
+    background: var(--highlight);
 }
-
 .main-nav a.active {
-    color: var(--primary-color);
-    background-color: #dbeafe;
-    font-weight: 600;
+    color: var(--accent);
+    border-color: rgba(0, 255, 136, 0.4);
+    background: var(--highlight);
 }
 
-/* Main content */
-.site-content {
-    padding: 2rem 0;
-}
+/* --------------------------------------------------------------- Content */
+.site-content { padding: 2.5rem 0 3rem; }
 
-/* Hero section */
+/* ----------------------------------------------------------------- Hero (legacy) */
 .hero {
-    background: linear-gradient(to right, var(--primary-color), var(--secondary-color));
-    color: white;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-top: 3px solid var(--accent);
+    color: var(--text);
     text-align: center;
     padding: 4rem 2rem;
     border-radius: var(--border-radius);
     margin-bottom: 2rem;
     box-shadow: var(--shadow);
 }
-
-.hero h1 {
-    font-size: 2.5rem;
-    margin-bottom: 1rem;
-    border-bottom: none;
-    color: white;
-}
-
+.hero h1 { border-bottom: none; color: var(--text); }
+.hero h1::after { margin-left: auto; margin-right: auto; }
 .subtitle {
-    font-size: 1.25rem;
+    font-size: 1.2rem;
     max-width: 800px;
     margin: 0 auto 2rem;
-    color: rgba(255, 255, 255, 0.9);
+    color: var(--text-soft);
 }
 
 .stats-overview {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 2rem;
-    margin-bottom: 2rem;
+    display: flex; flex-wrap: wrap; justify-content: center;
+    gap: 1.5rem; margin-bottom: 2rem;
 }
-
 .stat-card {
-    background-color: rgba(255, 255, 255, 0.1);
-    backdrop-filter: blur(5px);
-    padding: 1.5rem;
-    border-radius: var(--border-radius);
-    min-width: 180px;
-    transition: transform 0.3s ease;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    padding: 1.5rem; border-radius: var(--border-radius);
+    min-width: 180px; transition: transform 0.25s ease, border-color 0.25s ease;
 }
+.stat-card:hover { transform: translateY(-4px); border-color: var(--accent); }
+.stat-number { font-family: var(--font-display); font-size: 2.6rem; letter-spacing: 2px; color: var(--accent); margin-bottom: 0.4rem; }
+.stat-label { font-family: var(--font-mono); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 2px; color: var(--muted); }
 
-.stat-card:hover {
-    transform: translateY(-5px);
-}
+.cta-buttons { display: flex; justify-content: center; gap: 1rem; flex-wrap: wrap; }
 
-.stat-number {
-    font-size: 2.5rem;
-    font-weight: 700;
-    margin-bottom: 0.5rem;
-}
-
-.stat-label {
-    font-size: 0.875rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-}
-
-.cta-buttons {
-    display: flex;
-    justify-content: center;
-    gap: 1rem;
-    flex-wrap: wrap;
-}
-
-/* Buttons */
+/* ----------------------------------------------------------------- Buttons */
 .btn {
     display: inline-block;
-    background-color: var(--primary-color);
-    color: white;
-    padding: 0.75rem 1.5rem;
+    background: var(--surface-2);
+    color: var(--text);
+    padding: 0.7rem 1.4rem;
+    border: 1px solid var(--border);
     border-radius: var(--border-radius);
     text-decoration: none;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    letter-spacing: 1px;
     font-weight: 600;
-    transition: background-color 0.2s ease, transform 0.2s ease;
-    box-shadow: var(--shadow-sm);
+    transition: all 0.18s ease;
+    cursor: pointer;
 }
-
 .btn:hover {
-    background-color: var(--secondary-color);
-    color: white;
+    color: var(--accent);
+    border-color: var(--accent);
+    background: var(--highlight);
     transform: translateY(-2px);
-    box-shadow: var(--shadow);
 }
-
 .btn.primary {
-    background-color: white;
-    color: var(--primary-color);
+    background: var(--accent);
+    color: #05140d;
+    border-color: var(--accent);
+    box-shadow: 0 0 22px rgba(0, 255, 136, 0.25);
 }
+.btn.primary:hover { background: var(--accent-dim); color: #05140d; }
+.btn.secondary { background: var(--surface-2); color: var(--text-soft); }
+.btn.secondary:hover { color: var(--accent3); border-color: var(--accent3); }
+.btn.small, .btn-small { padding: 0.4rem 0.9rem; font-size: 0.78rem; }
+.btn.outline, .btn-outline { background: transparent; border: 1px solid var(--accent); color: var(--accent); }
+.btn.outline:hover, .btn-outline:hover { background: var(--accent); color: #05140d; }
 
-.btn.primary:hover {
-    background-color: rgba(255, 255, 255, 0.9);
-    color: var(--secondary-color);
-}
-
-.btn.secondary {
-    background-color: rgba(14, 116, 144, 0.1);
-    color: white;
-    border: 1px solid rgba(14, 116, 144, 0.4);
-}
-
-.btn.secondary:hover {
-    background-color: rgba(14, 116, 144, 0.18);
-}
-
-.btn.small {
-    padding: 0.5rem 1rem;
-    font-size: 0.875rem;
-}
-
-.btn.outline {
-    background-color: transparent;
-    border: 1px solid var(--primary-color);
-    color: var(--primary-color);
-}
-
-.btn.outline:hover {
-    background-color: var(--primary-color);
-    color: white;
-}
-
-.btn-outline {
-    background-color: transparent;
-    border: 1px solid var(--primary-color);
-    color: var(--primary-color);
-}
-
-.btn-outline:hover {
-    background-color: var(--primary-color);
-    color: white;
-}
-
-/* Sections */
-.latest-findings, .about-project {
-    background-color: white;
+/* ----------------------------------------------------------- Generic cards */
+.latest-findings, .about-project, .technical-analysis {
+    background: var(--surface);
+    border: 1px solid var(--border);
     padding: 2rem;
     border-radius: var(--border-radius);
     margin-bottom: 2rem;
@@ -282,615 +291,238 @@ p {
 }
 
 .report-summary {
-    border-left: 4px solid var(--primary-color);
+    border-left: 3px solid var(--accent);
     padding: 1.5rem;
-    background-color: rgba(37, 99, 235, 0.05);
+    background: var(--highlight);
     border-radius: 0 var(--border-radius) var(--border-radius) 0;
-}
-
-.mini-stats {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 2rem;
-    margin: 1.5rem 0;
-}
-
-.mini-stat {
-    flex: 1;
-    min-width: 200px;
-}
-
-.mini-stat .label {
-    display: block;
-    margin-bottom: 0.5rem;
-    color: var(--text-light);
-}
-
-.mini-stat .value {
-    font-size: 1.75rem;
-    font-weight: 700;
-    color: var(--primary-color);
-}
-
-.alert {
-    padding: 1rem;
-    border-radius: var(--border-radius);
-    margin-bottom: 1.5rem;
-}
-
-.alert.warning {
-    background-color: rgba(245, 158, 11, 0.1);
-    border-left: 4px solid var(--warning-color);
-    color: #92400e;
-}
-
-/* Report page styles */
-.page-header {
     margin-bottom: 2rem;
 }
 
-.report-actions {
-    display: flex;
-    gap: 1rem;
-    margin-top: 1rem;
-}
+.mini-stats { display: flex; flex-wrap: wrap; gap: 2rem; margin: 1.5rem 0; }
+.mini-stat { flex: 1; min-width: 200px; }
+.mini-stat .label { display: block; margin-bottom: 0.5rem; color: var(--muted); font-family: var(--font-mono); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 1px; }
+.mini-stat .value { font-family: var(--font-display); font-size: 1.9rem; letter-spacing: 1px; color: var(--accent); }
 
-.report-summary {
-    margin-bottom: 2rem;
-}
+.alert { padding: 1rem 1.25rem; border-radius: var(--border-radius); margin-bottom: 1.5rem; border: 1px solid var(--border); }
+.alert.warning { background: rgba(255, 204, 0, 0.08); border-left: 3px solid var(--warning-color); color: #ffe08a; }
 
-.summary-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1.5rem;
-}
+/* -------------------------------------------------------- Report summary grid */
+.page-header { margin-bottom: 2rem; }
+.report-actions { display: flex; gap: 1rem; margin-top: 1rem; flex-wrap: wrap; }
 
+.summary-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1.25rem; }
 .summary-card {
-    background-color: white;
-    padding: 1.5rem;
-    border-radius: var(--border-radius);
-    box-shadow: var(--shadow);
-    text-align: center;
-    transition: transform 0.3s ease;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 1.5rem; border-radius: var(--border-radius);
+    box-shadow: var(--shadow); text-align: center;
+    transition: transform 0.25s ease, border-color 0.25s ease;
 }
+.summary-card:hover { transform: translateY(-4px); border-color: var(--accent); }
+.summary-card h3 { font-family: var(--font-display); font-size: 2.6rem; letter-spacing: 1px; color: var(--accent); margin-bottom: 0.4rem; }
 
-.summary-card:hover {
-    transform: translateY(-5px);
-}
-
-.summary-card h3 {
-    font-size: 2.5rem;
-    color: var(--primary-color);
-    margin-bottom: 0.5rem;
-}
-
-/* Attack breakdown */
-.attack-breakdown {
-    margin-bottom: 2rem;
-}
-
-.breakdown-cards {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 1.5rem;
-}
-
+/* ------------------------------------------------------------ Attack breakdown */
+.attack-breakdown { margin-bottom: 2rem; }
+.breakdown-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.25rem; }
 .breakdown-card {
-    background-color: white;
-    padding: 1.5rem;
-    border-radius: var(--border-radius);
-    box-shadow: var(--shadow);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 1.5rem; border-radius: var(--border-radius); box-shadow: var(--shadow);
 }
+.stat-value { font-family: var(--font-display); font-size: 2.1rem; letter-spacing: 1px; color: var(--accent); margin-bottom: 0.5rem; }
 
-.stat-value {
-    font-size: 2rem;
-    font-weight: 700;
-    color: var(--primary-color);
-    margin-bottom: 0.5rem;
-}
+.progress-bar { height: 8px; background: var(--surface-3); border-radius: 999px; overflow: hidden; margin-bottom: 0.5rem; }
+.progress { height: 100%; background: linear-gradient(90deg, var(--accent-dim), var(--accent)); transition: width 1s ease-in-out; }
 
-.progress-bar {
-    height: 10px;
-    background-color: #e9ecef;
-    border-radius: 1rem;
-    overflow: hidden;
-    margin-bottom: 0.5rem;
-}
-
-.progress {
-    height: 100%;
-    background-color: var(--primary-color);
-    transition: width 1s ease-in-out;
-}
-
-/* Affected sites */
-.sites-list {
-    margin-bottom: 2rem;
-}
-
+/* ------------------------------------------------------------- Tables */
+.sites-list { margin-bottom: 2rem; }
 .sites-table-wrapper {
     overflow-x: auto;
-    background-color: white;
+    background: var(--surface);
+    border: 1px solid var(--border);
     border-radius: var(--border-radius);
     box-shadow: var(--shadow);
 }
-
-.sites-table {
-    width: 100%;
-    border-collapse: collapse;
-}
-
-.sites-table th,
-.sites-table td {
-    padding: 1rem;
-    text-align: left;
-    border-bottom: 1px solid #e5e7eb;
-}
-
+.sites-table { width: 100%; border-collapse: collapse; font-size: 0.92rem; }
+.sites-table th, .sites-table td { padding: 0.9rem 1rem; text-align: left; border-bottom: 1px solid var(--border); }
 .sites-table th {
-    background-color: #f9fafb;
-    font-weight: 600;
+    background: var(--surface-2);
+    font-family: var(--font-mono);
+    font-size: 0.74rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--accent);
+    border-bottom: 2px solid var(--accent);
 }
+.sites-table tr:last-child td { border-bottom: none; }
+.sites-table tbody tr { transition: background 0.15s ease; }
+.sites-table tbody tr:hover { background: var(--highlight); }
 
-.sites-table tr:last-child td {
-    border-bottom: none;
-}
-
-.sites-table tr:hover {
-    background-color: #f9fafb;
-}
-
-/* Technical analysis */
-.technical-analysis {
-    background-color: white;
-    padding: 2rem;
-    border-radius: var(--border-radius);
-    box-shadow: var(--shadow);
-}
-
-.analysis-content {
-    line-height: 1.7;
-}
-
-.analysis-content h2 {
-    margin-top: 2rem;
-    margin-bottom: 1rem;
-    font-size: 1.5rem;
-}
-
-.analysis-content ul,
-.analysis-content ol {
-    margin-left: 1.5rem;
-    margin-bottom: 1.5rem;
-}
-
-.analysis-content p {
-    margin-bottom: 1.25rem;
-}
-
+/* ------------------------------------------------------ Analysis prose */
+.analysis-content { line-height: 1.75; }
+.analysis-content h2 { margin-top: 2rem; margin-bottom: 1rem; font-size: 1.5rem; color: var(--text); }
+.analysis-content ul, .analysis-content ol { margin-left: 1.5rem; margin-bottom: 1.5rem; }
+.analysis-content p { margin-bottom: 1.2rem; }
 .analysis-content pre {
-    background-color: #f9fafb;
-    padding: 1.25rem;
-    border-radius: var(--border-radius);
-    overflow-x: auto;
-    margin-bottom: 1.25rem;
-    border: 1px solid #e5e7eb;
+    background: #05050a;
+    padding: 1.2rem; border-radius: var(--border-radius);
+    overflow-x: auto; margin-bottom: 1.2rem;
+    border: 1px solid var(--border); border-left: 3px solid var(--accent);
+    font-size: 0.86rem; line-height: 1.6;
 }
-
-.analysis-content code {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-    background-color: #f9fafb;
-    padding: 0.125rem 0.25rem;
-    border-radius: 0.25rem;
-    font-size: 0.875em;
-    border: 1px solid #e5e7eb;
+.analysis-content code, code {
+    font-family: var(--font-mono);
+    background: var(--surface-3);
+    padding: 0.12rem 0.4rem; border-radius: 4px;
+    font-size: 0.86em; color: var(--accent3);
+    border: 1px solid var(--border);
 }
+.analysis-content pre code { background: none; border: none; padding: 0; color: var(--text-soft); }
 
-/* Reports list page */
+/* ---------------------------------------------------- Reports list page */
 .report-filter {
-    background-color: white;
-    padding: 1.5rem;
-    border-radius: var(--border-radius);
-    margin-bottom: 2rem;
-    box-shadow: var(--shadow);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 1.5rem; border-radius: var(--border-radius);
+    margin-bottom: 2rem; box-shadow: var(--shadow);
 }
-
-.filter-controls {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1.5rem;
-}
-
-.filter-group {
-    flex: 1;
-    min-width: 200px;
-}
-
+.filter-controls { display: flex; flex-wrap: wrap; gap: 1.5rem; }
+.filter-group { flex: 1; min-width: 200px; }
 .filter-select {
-    width: 100%;
-    padding: 0.75rem;
+    width: 100%; padding: 0.7rem;
     border-radius: var(--border-radius);
-    border: 1px solid #e5e7eb;
-    background-color: white;
-    font-size: 1rem;
-    margin-top: 0.5rem;
+    border: 1px solid var(--border);
+    background: var(--surface-2); color: var(--text);
+    font-family: var(--font-mono); font-size: 0.9rem; margin-top: 0.5rem;
 }
+.year-group { margin-bottom: 3rem; }
+.month-group { margin-bottom: 2rem; }
 
-.year-group {
-    margin-bottom: 3rem;
-}
-
-.month-group {
-    margin-bottom: 2rem;
-}
-
-.reports-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    gap: 1.5rem;
-    margin-top: 1rem;
-}
-
+.reports-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.25rem; margin-top: 1rem; }
 .report-card {
-    background-color: white;
+    background: var(--surface);
+    border: 1px solid var(--border);
     border-radius: var(--border-radius);
-    padding: 1.5rem;
-    box-shadow: var(--shadow);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    padding: 1.5rem; box-shadow: var(--shadow);
+    transition: transform 0.25s ease, border-color 0.25s ease;
 }
+.report-card:hover { transform: translateY(-4px); border-color: var(--accent); box-shadow: var(--shadow-lg); }
+.report-date { color: var(--muted); font-family: var(--font-mono); font-size: 0.8rem; margin-bottom: 0.5rem; }
+.report-card h4 { font-size: 1.2rem; margin-bottom: 1rem; color: var(--text); }
+.report-stats { display: flex; gap: 1.5rem; margin-bottom: 1.5rem; }
+.report-stats .stat { flex: 1; }
+.report-stats .value { display: block; font-family: var(--font-display); font-size: 1.5rem; letter-spacing: 1px; color: var(--accent); margin-bottom: 0.25rem; }
+.report-stats .label { font-family: var(--font-mono); font-size: 0.7rem; text-transform: uppercase; letter-spacing: 1px; color: var(--muted); }
 
-.report-card:hover {
-    transform: translateY(-5px);
-    box-shadow: var(--shadow-lg);
-}
-
-.report-date {
-    color: var(--text-light);
-    font-size: 0.875rem;
-    margin-bottom: 0.5rem;
-}
-
-.report-card h4 {
-    font-size: 1.25rem;
-    margin-bottom: 1rem;
-}
-
-.report-stats {
-    display: flex;
-    gap: 1.5rem;
-    margin-bottom: 1.5rem;
-}
-
-.report-stats .stat {
-    flex: 1;
-}
-
-.report-stats .value {
-    display: block;
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: var(--primary-color);
-    margin-bottom: 0.25rem;
-}
-
-.report-stats .label {
-    font-size: 0.75rem;
-    color: var(--text-light);
-}
-
-.new-patterns {
-    margin-bottom: 1.5rem;
-    padding: 0.5rem 0.75rem;
-    background-color: rgba(245, 158, 11, 0.1);
-    border-radius: var(--border-radius);
-    font-size: 0.875rem;
-}
-
+.new-patterns { margin-bottom: 1.5rem; padding: 0.5rem 0.75rem; background: rgba(255, 204, 0, 0.08); border: 1px solid rgba(255, 204, 0, 0.25); border-radius: var(--border-radius); font-size: 0.85rem; }
 .badge {
-    display: inline-block;
-    background-color: var(--warning-color);
-    color: white;
-    padding: 0.125rem 0.375rem;
-    border-radius: 0.25rem;
-    font-weight: 600;
-    font-size: 0.75rem;
-    margin-right: 0.375rem;
+    display: inline-block; background: var(--accent4); color: #1a1500;
+    padding: 0.12rem 0.45rem; border-radius: 4px; font-weight: 700;
+    font-family: var(--font-mono); font-size: 0.7rem; margin-right: 0.375rem;
 }
 
 .view-report {
-    display: block;
-    text-align: center;
-    background-color: #f9fafb;
-    padding: 0.75rem;
-    border-radius: var(--border-radius);
-    font-weight: 500;
-    transition: background-color 0.2s;
+    display: block; text-align: center;
+    background: var(--surface-2); border: 1px solid var(--border);
+    padding: 0.7rem; border-radius: var(--border-radius);
+    font-family: var(--font-mono); font-size: 0.82rem; letter-spacing: 1px;
+    color: var(--accent); transition: all 0.18s;
 }
+.view-report:hover { background: var(--highlight); border-color: var(--accent); }
 
-.view-report:hover {
-    background-color: var(--primary-color);
-    color: white;
-}
-
-.pagination {
-    text-align: center;
-    margin-top: 3rem;
-}
-
+.pagination { text-align: center; margin-top: 3rem; }
 .pagination-btn {
-    background-color: white;
-    border: 1px solid #e5e7eb;
-    padding: 0.75rem 1.5rem;
-    border-radius: var(--border-radius);
-    font-size: 1rem;
-    cursor: pointer;
-    transition: background-color 0.2s, border-color 0.2s;
-    box-shadow: var(--shadow-sm);
+    background: var(--surface-2); border: 1px solid var(--border);
+    padding: 0.7rem 1.4rem; border-radius: var(--border-radius);
+    font-family: var(--font-mono); font-size: 0.9rem; color: var(--text);
+    cursor: pointer; transition: all 0.18s;
 }
+.pagination-btn:hover { border-color: var(--accent); color: var(--accent); }
 
-.pagination-btn:hover {
-    background-color: #f9fafb;
-    border-color: #d1d5db;
-}
-
-/* Footer styles */
+/* ---------------------------------------------------------------- Footer */
 .site-footer {
-    background-color: #0f172a;
-    color: white;
-    padding: 3rem 0;
-    margin-top: 3rem;
+    background: #06060a;
+    border-top: 1px solid var(--border);
+    color: var(--text-soft);
+    padding: 3rem 0 2rem;
+    margin-top: 4rem;
+    position: relative;
 }
-
-.footer-content {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 3rem;
+.site-footer::before {
+    content: '';
+    position: absolute; top: -1px; left: 0; right: 0; height: 1px;
+    background: linear-gradient(90deg, transparent, var(--accent), transparent);
+    opacity: 0.5;
 }
+.footer-content { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 3rem; }
+.footer-logo img { height: 38px; margin-bottom: 1rem; }
+.footer-logo p { color: var(--muted); font-size: 0.85rem; }
+.footer-links h3 { color: var(--text); margin-bottom: 1.1rem; font-family: var(--font-mono); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 2px; }
+.footer-links ul { list-style: none; }
+.footer-links li { margin-bottom: 0.7rem; }
+.footer-links a { color: var(--muted); font-size: 0.86rem; }
+.footer-links a:hover { color: var(--accent); }
+.footer-bottom { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--border); text-align: center; font-size: 0.82rem; color: var(--muted); }
 
-.footer-logo img {
-    height: 40px;
-    margin-bottom: 1rem;
-}
-
-.footer-logo p {
-    color: #9ca3af;
-    font-size: 0.875rem;
-}
-
-.footer-links h3 {
-    color: white;
-    margin-bottom: 1.25rem;
-    font-size: 1rem;
-}
-
-.footer-links ul {
-    list-style: none;
-}
-
-.footer-links li {
-    margin-bottom: 0.75rem;
-}
-
-.footer-links a {
-    color: #9ca3af;
-    text-decoration: none;
-    transition: color 0.2s ease;
-    font-size: 0.875rem;
-}
-
-.footer-links a:hover {
-    color: white;
-}
-
-.footer-bottom {
-    margin-top: 3rem;
-    padding-top: 1.5rem;
-    border-top: 1px solid #374151;
-    text-align: center;
-    font-size: 0.875rem;
-    color: #9ca3af;
-}
-
-/* Responsive styles */
-@media (max-width: 768px) {
-    .site-header .container {
-        flex-direction: column;
-    }
-    
-    .main-nav ul {
-        margin-top: 1rem;
-        justify-content: center;
-    }
-    
-    .hero h1 {
-        font-size: 1.875rem;
-    }
-    
-    .stat-card {
-        width: 100%;
-    }
-    
-    .footer-content {
-        grid-template-columns: 1fr;
-    }
-
-    .stats-overview {
-        flex-direction: column;
-        align-items: center;
-    }
-
-    .stat-card {
-        width: 80%;
-    }
-}
-
-/* Add styles for the detailed URL analysis section */
-.detailed-findings {
-  margin-top: 3rem;
-}
-
+/* ----------------------------------------------------- Detailed URL cards */
+.detailed-findings { margin-top: 3rem; }
 .url-analysis-card {
-  background-color: #fff;
-  border-radius: 8px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-  margin-bottom: 2rem;
-  overflow: hidden;
-  transition: box-shadow 0.3s ease;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius);
+    box-shadow: var(--shadow);
+    margin-bottom: 2rem; overflow: hidden;
+    transition: box-shadow 0.25s ease, border-color 0.25s ease;
 }
+.url-analysis-card.highlight { border-color: var(--accent4); box-shadow: 0 0 22px rgba(255, 204, 0, 0.25); }
+.url-header { background: var(--surface-2); padding: 1.4rem; border-bottom: 1px solid var(--border); }
+.url-header h3 { margin: 0 0 0.5rem 0; color: var(--text); word-break: break-all; }
+.url-meta { display: flex; gap: 1.5rem; font-family: var(--font-mono); font-size: 0.82rem; color: var(--muted); flex-wrap: wrap; }
+.url-type { background: rgba(61, 158, 255, 0.12); color: var(--accent3); border: 1px solid rgba(61, 158, 255, 0.3); border-radius: 4px; padding: 0.2rem 0.7rem; font-weight: 600; }
+.url-findings strong { color: var(--accent2); }
 
-.url-analysis-card.highlight {
-  box-shadow: 0 0 15px rgba(255, 165, 0, 0.7);
-}
-
-.url-header {
-  background-color: #f5f7fa;
-  padding: 1.5rem;
-  border-bottom: 1px solid #eaeef3;
-}
-
-.url-header h3 {
-  margin: 0 0 0.5rem 0;
-  color: #2c3e50;
-}
-
-.url-meta {
-  display: flex;
-  gap: 1.5rem;
-  font-size: 0.9rem;
-  color: #6c757d;
-}
-
-.url-type {
-  background-color: #e1f5fe;
-  color: #0277bd;
-  border-radius: 4px;
-  padding: 0.25rem 0.75rem;
-  font-weight: 500;
-}
-
-.url-findings strong {
-  color: #e74c3c;
-}
-
-.url-tabs {
-  display: flex;
-  background-color: #f8f9fa;
-  border-bottom: 1px solid #eaeef3;
-  padding: 0 1rem;
-}
-
+.url-tabs { display: flex; background: var(--surface-2); border-bottom: 1px solid var(--border); padding: 0 1rem; flex-wrap: wrap; }
 .tab-btn {
-  background: none;
-  border: none;
-  padding: 1rem 1.25rem;
-  cursor: pointer;
-  color: #6c757d;
-  font-weight: 500;
-  border-bottom: 2px solid transparent;
-  transition: all 0.2s ease;
+    background: none; border: none; padding: 0.9rem 1.2rem; cursor: pointer;
+    color: var(--muted); font-family: var(--font-mono); font-size: 0.82rem; font-weight: 500;
+    border-bottom: 2px solid transparent; transition: all 0.18s ease;
 }
+.tab-btn:hover { color: var(--accent3); }
+.tab-btn.active { color: var(--accent); border-bottom-color: var(--accent); }
+.tab-content { display: none; padding: 1.5rem; }
+.tab-content.active { display: block; }
 
-.tab-btn:hover {
-  color: #3498db;
+.code-block { background: #05050a; border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: var(--border-radius); overflow: hidden; margin-bottom: 1.5rem; }
+.code-block pre { margin: 0; padding: 1.2rem; font-family: var(--font-mono); font-size: 0.86rem; line-height: 1.6; overflow-x: auto; }
+.code-block code { background: none; padding: 0; color: var(--text-soft); border: none; }
+
+.findings-groups { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.25rem; }
+.findings-group { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius); padding: 1.2rem; }
+.findings-group h4 { margin-top: 0; margin-bottom: 1rem; color: var(--text); font-family: var(--font-mono); font-size: 0.92rem; text-transform: uppercase; letter-spacing: 1px; }
+.findings-group ul { margin: 0; padding: 0; list-style: none; }
+.findings-group li { margin-bottom: 0.75rem; }
+.findings-group code { background: var(--surface-3); padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.82rem; color: var(--accent3); border: 1px solid var(--border); word-break: break-all; display: inline-block; max-width: 100%; }
+
+.malicious-url { color: var(--accent2); text-decoration: none; word-break: break-all; }
+.malicious-url:hover { text-decoration: underline; }
+
+/* ------------------------------------------------------------ Utilities */
+.mono { font-family: var(--font-mono); }
+.glow-green { text-shadow: 0 0 18px rgba(0, 255, 136, 0.5); }
+.text-accent { color: var(--accent); }
+.text-red { color: var(--accent2); }
+.text-blue { color: var(--accent3); }
+.text-gold { color: var(--accent4); }
+
+@keyframes blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
+.cursor::after { content: '_'; animation: blink 1s step-end infinite; color: var(--accent); }
+
+/* ----------------------------------------------------------- Responsive */
+@media (max-width: 768px) {
+    .site-header .container { flex-direction: column; gap: 0.8rem; }
+    .main-nav ul { flex-wrap: wrap; justify-content: center; }
+    .footer-content { grid-template-columns: 1fr; }
+    .stats-overview { flex-direction: column; align-items: center; }
+    .stat-card { width: 100%; }
+    .report-stats { flex-wrap: wrap; }
 }
-
-.tab-btn.active {
-  color: #2c3e50;
-  border-bottom-color: #3498db;
-}
-
-.tab-content {
-  display: none;
-  padding: 1.5rem;
-}
-
-.tab-content.active {
-  display: block;
-}
-
-.code-block {
-  background-color: #f8f9fb;
-  border-radius: 6px;
-  overflow: hidden;
-  margin-bottom: 1.5rem;
-}
-
-.code-block pre {
-  margin: 0;
-  padding: 1.25rem;
-  font-family: 'Monaco', 'Consolas', monospace;
-  font-size: 0.9rem;
-  line-height: 1.5;
-  overflow-x: auto;
-}
-
-.code-block code {
-  background: none;
-  padding: 0;
-  color: #333;
-}
-
-.findings-groups {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 1.5rem;
-}
-
-.findings-group {
-  background-color: #f8f9fb;
-  border-radius: 6px;
-  padding: 1.25rem;
-}
-
-.findings-group h4 {
-  margin-top: 0;
-  margin-bottom: 1rem;
-  color: #2c3e50;
-  font-size: 1rem;
-}
-
-.findings-group ul {
-  margin: 0;
-  padding: 0;
-  list-style-type: none;
-}
-
-.findings-group li {
-  margin-bottom: 0.75rem;
-}
-
-.findings-group code {
-  background-color: #f1f3f5;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  font-size: 0.85rem;
-  word-break: break-all;
-  display: inline-block;
-  max-width: 100%;
-  overflow-x: auto;
-}
-
-.malicious-url {
-  color: #e74c3c;
-  text-decoration: none;
-  word-break: break-all;
-}
-
-.malicious-url:hover {
-  text-decoration: underline;
-}
-
-.btn-small {
-  display: inline-block;
-  padding: 0.25rem 0.75rem;
-  font-size: 0.85rem;
-  background-color: #3498db;
-  color: white;
-  border-radius: 4px;
-  text-decoration: none;
-  transition: background-color 0.2s ease;
-}
-
-.btn-small:hover {
-  background-color: #2980b9;
-} 

--- a/docs/examples/colorcpl.exe-your-monitor-display-profile-is-corrupt.html
+++ b/docs/examples/colorcpl.exe-your-monitor-display-profile-is-corrupt.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Your Monitor Display Profile is Corrupt - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/docs/examples/colorcpl.exe-your-monitor-is-displaying-colors-incorrectly.html
+++ b/docs/examples/colorcpl.exe-your-monitor-is-displaying-colors-incorrectly.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Your Monitor is Displaying Colors Incorrectly - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/docs/examples/consentfix-consentfix-oauth-token-theft.html
+++ b/docs/examples/consentfix-consentfix-oauth-token-theft.html
@@ -1,0 +1,362 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>ConsentFix OAuth Token Theft - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
+        body {
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
+            margin: 0;
+            padding: 0;
+        }
+        .center-box {
+            position: fixed;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
+            padding: 32px 24px 24px 24px;
+            text-align: center;
+            min-width: 300px;
+            max-width: 500px;
+        }
+        .example-title {
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
+            margin-bottom: 10px;
+            color: var(--accent);
+        }
+        .example-desc {
+            color: var(--text-soft);
+            font-size: 13px;
+            margin-top: 10px;
+            line-height: 1.4;
+        }
+        .step-container {
+            margin: 20px 0;
+            text-align: left;
+        }
+        .step {
+            position: relative;
+            padding: 16px 16px 16px 52px;
+            margin: 10px 0;
+            font-size: 14px;
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
+        }
+        .step-number {
+            position: absolute;
+            left: 14px;
+            top: 50%;
+            transform: translateY(-50%);
+            width: 28px;
+            height: 28px;
+            border-radius: 50%;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 800;
+            font-size: 14px;
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
+        }
+        .step-content {
+            display: inline;
+        }
+        /* Keycap-style emphasis for shortcuts and important words */
+        .step-content strong {
+            color: var(--accent);
+            font-family: var(--font-mono);
+            font-weight: 700;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
+            padding: 1px 6px;
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
+        }
+        .step-content code {
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
+            padding: 1px 6px;
+            border-radius: var(--border-radius);
+        }
+        .action-btn {
+            background: var(--accent);
+            color: var(--bg);
+            border: none;
+            border-radius: var(--border-radius);
+            padding: 12px 32px;
+            font-family: var(--font-mono);
+            font-size: 16px;
+            font-weight: 700;
+            letter-spacing: 0.5px;
+            cursor: pointer;
+            margin-top: 18px;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
+        }
+        .action-btn:active {
+            background: var(--accent-dim);
+        }
+        .action-btn:disabled {
+            background: var(--muted);
+            color: var(--surface);
+            cursor: not-allowed;
+        }
+        .copied-msg {
+            color: var(--accent);
+            font-family: var(--font-mono);
+            margin-top: 16px;
+            font-size: 14px;
+            display: none;
+        }
+        .warning-msg {
+            color: var(--accent2);
+            font-family: var(--font-mono);
+            margin-top: 16px;
+            font-size: 14px;
+            display: none;
+        }
+        .progress-bar {
+            width: 100%;
+            height: 4px;
+            background: var(--surface-3);
+            border-radius: 2px;
+            margin: 16px 0;
+            overflow: hidden;
+        }
+        .progress-fill {
+            height: 100%;
+            background: var(--accent);
+            width: 0%;
+            transition: width 0.3s ease;
+        }
+        .step-highlight {
+            background: var(--highlight);
+            border-color: var(--accent4);
+        }
+        .step-completed {
+            background: var(--surface-3);
+            border-color: var(--accent);
+        }
+        .step-completed .step-number {
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
+        }
+        /* Special treatment for the first step like ClickFix callout */
+        #step-1 {
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
+        }
+        #step-1 .step-number {
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
+        }
+        .back-link {
+            position: absolute;
+            top: 20px;
+            left: 20px;
+            color: var(--accent);
+            font-family: var(--font-mono);
+            text-decoration: none;
+            font-size: 14px;
+            font-weight: 500;
+            transition: color 0.18s ease;
+        }
+        .back-link:hover {
+            color: var(--accent-dim);
+            text-decoration: underline;
+        }
+        .disclaimer {
+            position: absolute;
+            bottom: 20px;
+            left: 50%;
+            transform: translateX(-50%);
+            font-family: var(--font-mono);
+            font-size: 12px;
+            color: var(--muted);
+            text-align: center;
+            max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
+        }
+    </style>
+</head>
+<body>
+    <a href="/ClickGrab/techniques/consentfix.html" class="back-link">← Back to ConsentFix</a>
+    
+    <div class="center-box">
+        <div class="example-title">ConsentFix OAuth Token Theft</div>
+        <div class="example-desc"><p>To complete the verification, please copy the URL from your browser's address bar and paste it in the box below.</p></div>
+        
+        <div class="progress-bar">
+            <div class="progress-fill" id="progressFill"></div>
+        </div>
+        
+        <div class="step-container" id="stepContainer">
+            
+            <div class="step" id="step-1">
+                <span class="step-number">1</span>
+                <span class="step-content"><p>Copy the <strong>URL</strong> from your browser's address bar</p></span>
+            </div>
+            
+            <div class="step" id="step-2">
+                <span class="step-number">2</span>
+                <span class="step-content"><p>Paste it in the <strong>verification box</strong> below</p></span>
+            </div>
+            
+            <div class="step" id="step-3">
+                <span class="step-number">3</span>
+                <span class="step-content"><p>Click <strong>Verify</strong></p></span>
+            </div>
+            
+        </div>
+        
+        <div style="margin: 8px 0;">
+            
+        </div>
+        <button class="action-btn" id="actionBtn">Next Step</button>
+        <div class="copied-msg" id="copiedMsg">Copied to clipboard!</div>
+        <div class="warning-msg" id="warningMsg">⚠️ This is a demonstration - do not run this command!</div>
+    </div>
+    
+    <div class="disclaimer">
+        <strong>Educational Example:</strong> This is a demonstration of what a social engineering attack might look like. 
+        Never run commands from untrusted sources. This example is for educational purposes only.
+    </div>
+    
+    <script>
+        let currentStep = 0;
+        const totalSteps = 3;
+        const steps = ["Copy the **URL** from your browser\u0027s address bar", "Paste it in the **verification box** below", "Click **Verify**"];
+        let textToCopy = "ConsentFix";
+        
+        function updateProgress() {
+            const progress = (currentStep / totalSteps) * 100;
+            document.getElementById('progressFill').style.width = progress + '%';
+        }
+        
+        function highlightCurrentStep() {
+            // Remove previous highlights
+            document.querySelectorAll('.step').forEach(step => {
+                step.classList.remove('step-highlight');
+            });
+            
+            // Highlight current step
+            if (currentStep < totalSteps) {
+                const currentStepEl = document.getElementById('step-' + (currentStep + 1));
+                if (currentStepEl) {
+                    currentStepEl.classList.add('step-highlight');
+                }
+            }
+        }
+        
+        function markStepCompleted(stepIndex) {
+            const stepEl = document.getElementById('step-' + stepIndex);
+            if (stepEl) {
+                stepEl.classList.remove('step-highlight');
+                stepEl.classList.add('step-completed');
+            }
+        }
+        
+        function showCopiedMsg() {
+            const msg = document.getElementById('copiedMsg');
+            msg.style.display = 'block';
+            setTimeout(() => { msg.style.display = 'none'; }, 2000);
+        }
+        
+        function showWarningMsg() {
+            const msg = document.getElementById('warningMsg');
+            msg.style.display = 'block';
+            setTimeout(() => { msg.style.display = 'none'; }, 3000);
+        }
+        
+        function fallbackCopy() {
+            const temp = document.createElement("textarea");
+            temp.value = textToCopy;
+            document.body.appendChild(temp);
+            temp.select();
+            document.execCommand("copy");
+            document.body.removeChild(temp);
+            showCopiedMsg();
+        }
+        
+        function copyToClipboard() {
+            if (navigator.clipboard) {
+                navigator.clipboard.writeText(textToCopy).then(function() {
+                    showCopiedMsg();
+                }, function() {
+                    fallbackCopy();
+                });
+            } else {
+                fallbackCopy();
+            }
+        }
+        
+        
+
+        document.getElementById('actionBtn').addEventListener('click', function() {
+            if (currentStep < totalSteps) {
+                // Mark current step as completed
+                markStepCompleted(currentStep + 1);
+                currentStep++;
+                updateProgress();
+                highlightCurrentStep();
+                
+                // Update button text
+                if (currentStep < totalSteps) {
+                    this.textContent = "Next Step";
+                } else {
+                    this.textContent = "Copy Command";
+                }
+            } else {
+                // Final step - copy command
+                copyToClipboard();
+                showWarningMsg();
+            }
+        });
+        
+        // Initialize
+        updateProgress();
+        highlightCurrentStep();
+    </script>
+</body>
+</html>

--- a/docs/examples/dcomcnfg.exe-open-component-services.html
+++ b/docs/examples/dcomcnfg.exe-open-component-services.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Open Component Services - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/docs/examples/explorer-shell-uris-open-recycle-bin.html
+++ b/docs/examples/explorer-shell-uris-open-recycle-bin.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Open Recycle Bin - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/docs/examples/explorer-shell-uris-open-startup-folder.html
+++ b/docs/examples/explorer-shell-uris-open-startup-folder.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Open Startup folder - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/docs/examples/msiexec.exe-quiet-install-from-url-demo.html
+++ b/docs/examples/msiexec.exe-quiet-install-from-url-demo.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Quiet install from URL (demo) - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/docs/examples/msra.exe-get-remote-support.html
+++ b/docs/examples/msra.exe-get-remote-support.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Get Remote Support - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/docs/examples/office-uri-open-excel-via-uri-safe-demo.html
+++ b/docs/examples/office-uri-open-excel-via-uri-safe-demo.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Open Excel via URI (safe demo) - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/docs/examples/powershell.exe-fix-network-configuration.html
+++ b/docs/examples/powershell.exe-fix-network-configuration.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Fix Network Configuration - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/docs/examples/powershell.exe-fix-windows-security-update.html
+++ b/docs/examples/powershell.exe-fix-windows-security-update.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Fix Windows Security Update - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/docs/examples/search-ms-open-explorer-search-to-a-folder.html
+++ b/docs/examples/search-ms-open-explorer-search-to-a-folder.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Open Explorer search to a folder - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/docs/examples/taskmgr.exe-open-file-location-explorer-window.html
+++ b/docs/examples/taskmgr.exe-open-file-location-explorer-window.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Open file location (Explorer window) - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,482 +5,308 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ClickGrab - Advanced Threat Intelligence for Clipboard Hijacking Attacks</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <style>
+    /* ---- Hero ------------------------------------------------------ */
     .intel-hero {
-        background: linear-gradient(140deg, #082f49 0%, #0f766e 55%, #0891b2 100%);
-        color: #e2f2ff;
-        border-radius: 20px;
-        padding: 3.5rem 2.25rem;
+        background:
+            linear-gradient(135deg, var(--surface) 0%, var(--surface-2) 100%);
+        color: var(--text);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        border-radius: var(--border-radius);
+        padding: 3.25rem 2.25rem;
         margin-bottom: 2.5rem;
-        box-shadow: 0 18px 45px rgba(8, 47, 73, 0.25);
+        box-shadow: var(--shadow);
         position: relative;
         overflow: hidden;
     }
-
+    .intel-hero::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-image:
+            linear-gradient(rgba(0,255,136,0.04) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(0,255,136,0.04) 1px, transparent 1px);
+        background-size: 34px 34px;
+        pointer-events: none;
+    }
     .intel-hero::after {
         content: '';
         position: absolute;
         inset: 0;
         background:
-            radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.14), transparent 36%),
-            radial-gradient(circle at 82% 8%, rgba(207, 250, 254, 0.2), transparent 34%);
+            radial-gradient(circle at 12% 12%, rgba(0, 255, 136, 0.16), transparent 38%),
+            radial-gradient(circle at 88% 4%, rgba(61, 158, 255, 0.16), transparent 36%);
         pointer-events: none;
     }
-
-    .intel-hero-content {
-        position: relative;
-        z-index: 1;
-    }
+    .intel-hero-content { position: relative; z-index: 1; }
 
     .hero-kicker {
         display: inline-flex;
         align-items: center;
         gap: 0.45rem;
-        font-size: 0.82rem;
-        letter-spacing: 0.08em;
+        font-family: var(--font-mono);
+        font-size: 0.74rem;
+        letter-spacing: 0.18em;
         text-transform: uppercase;
-        font-weight: 700;
-        color: #d1fae5;
-        background: rgba(3, 7, 18, 0.28);
-        border: 1px solid rgba(255, 255, 255, 0.2);
-        padding: 0.45rem 0.8rem;
+        font-weight: 600;
+        color: var(--accent);
+        background: var(--highlight);
+        border: 1px solid rgba(0, 255, 136, 0.3);
+        padding: 0.4rem 0.85rem;
         border-radius: 999px;
-        margin-bottom: 1rem;
+        margin-bottom: 1.25rem;
+    }
+    .hero-kicker::before {
+        content: '';
+        width: 7px; height: 7px; border-radius: 50%;
+        background: var(--accent);
+        box-shadow: 0 0 8px var(--accent);
+        animation: blink 1.6s ease-in-out infinite;
     }
 
     .hero-title {
-        font-size: clamp(2rem, 4vw, 3rem);
-        margin-bottom: 0.85rem;
-        line-height: 1.15;
+        font-family: var(--font-display);
+        font-weight: 400;
+        font-size: clamp(2.4rem, 5vw, 3.8rem);
+        letter-spacing: 2px;
+        line-height: 1.04;
+        margin-bottom: 0.95rem;
         border-bottom: none;
-        color: #f8fafc;
+        background: linear-gradient(135deg, var(--accent) 0%, var(--accent-dim) 45%, var(--accent3) 100%);
+        -webkit-background-clip: text;
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
     }
+    .hero-title::after { display: none; }
 
     .hero-subtitle {
-        color: rgba(248, 250, 252, 0.92);
+        color: var(--text-soft);
         max-width: 900px;
-        font-size: 1.12rem;
-        margin-bottom: 1.6rem;
+        font-size: 1.08rem;
+        margin-bottom: 1.5rem;
     }
 
     .trend-chip {
         display: inline-flex;
         align-items: center;
-        gap: 0.45rem;
+        gap: 0.5rem;
+        font-family: var(--font-mono);
         border-radius: 999px;
-        font-size: 0.9rem;
-        font-weight: 600;
-        padding: 0.45rem 0.9rem;
+        font-size: 0.82rem;
+        font-weight: 500;
+        padding: 0.4rem 0.9rem;
         margin-bottom: 2rem;
-        border: 1px solid transparent;
+        border: 1px solid var(--border);
+        background: var(--surface-3);
+        color: var(--text-soft);
     }
-
-    .trend-chip.up {
-        background: rgba(254, 242, 242, 0.16);
-        color: #fee2e2;
-        border-color: rgba(248, 113, 113, 0.45);
-    }
-
-    .trend-chip.down {
-        background: rgba(236, 253, 245, 0.16);
-        color: #d1fae5;
-        border-color: rgba(16, 185, 129, 0.45);
-    }
-
-    .trend-chip.steady {
-        background: rgba(236, 253, 245, 0.14);
-        color: #ccfbf1;
-        border-color: rgba(45, 212, 191, 0.45);
-    }
+    .trend-chip.up { color: #ffb3c4; border-color: rgba(255, 51, 102, 0.45); background: rgba(255, 51, 102, 0.08); }
+    .trend-chip.down { color: var(--accent); border-color: rgba(0, 255, 136, 0.45); background: var(--highlight); }
+    .trend-chip.steady { color: var(--accent3); border-color: rgba(61, 158, 255, 0.45); background: rgba(61, 158, 255, 0.08); }
 
     .stats-showcase {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+        gap: 0.85rem;
         margin-bottom: 2rem;
     }
-
     .stat-box {
-        background: rgba(8, 47, 73, 0.45);
-        border: 1px solid rgba(186, 230, 253, 0.3);
-        border-radius: 14px;
+        background: rgba(5, 5, 10, 0.55);
+        border: 1px solid var(--border);
+        border-left: 2px solid rgba(0, 255, 136, 0.45);
+        border-radius: var(--border-radius);
         padding: 1rem 1.1rem;
-        backdrop-filter: blur(7px);
     }
-
     .stat-label {
         display: block;
-        font-size: 0.75rem;
+        font-family: var(--font-mono);
+        font-size: 0.68rem;
         text-transform: uppercase;
-        letter-spacing: 0.07em;
-        color: #bfdbfe;
-        margin-bottom: 0.35rem;
+        letter-spacing: 0.12em;
+        color: var(--muted);
+        margin-bottom: 0.4rem;
     }
-
     .stat-number {
         display: block;
-        font-size: clamp(1.35rem, 2.8vw, 1.95rem);
-        color: #f8fafc;
-        font-weight: 700;
-        line-height: 1.2;
+        font-family: var(--font-display);
+        font-size: clamp(1.7rem, 3vw, 2.3rem);
+        letter-spacing: 1px;
+        color: var(--accent);
+        line-height: 1.1;
     }
 
-    .hero-cta {
-        display: flex;
-        gap: 0.75rem;
-        flex-wrap: wrap;
-    }
-
+    .hero-cta { display: flex; gap: 0.7rem; flex-wrap: wrap; }
     .cta-btn {
         display: inline-flex;
         align-items: center;
         gap: 0.45rem;
+        font-family: var(--font-mono);
+        font-size: 0.84rem;
+        letter-spacing: 0.5px;
         font-weight: 600;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         text-decoration: none;
-        padding: 0.8rem 1.1rem;
-        transition: transform 0.2s ease, box-shadow 0.2s ease;
+        padding: 0.75rem 1.15rem;
+        border: 1px solid var(--border);
+        transition: transform 0.18s ease, border-color 0.18s ease, color 0.18s ease, background 0.18s ease;
     }
-
-    .cta-btn:hover {
-        transform: translateY(-2px);
-    }
-
+    .cta-btn:hover { transform: translateY(-2px); }
     .cta-btn.primary {
-        background: #f8fafc;
-        color: #0f172a;
-        box-shadow: 0 10px 18px rgba(8, 47, 73, 0.2);
+        background: var(--accent);
+        color: #05140d;
+        border-color: var(--accent);
+        box-shadow: 0 0 22px rgba(0, 255, 136, 0.25);
     }
+    .cta-btn.primary:hover { background: var(--accent-dim); color: #05140d; }
+    .cta-btn.secondary { background: var(--surface-2); color: var(--text-soft); }
+    .cta-btn.secondary:hover { color: var(--accent3); border-color: var(--accent3); background: rgba(61, 158, 255, 0.08); }
 
-    .cta-btn.secondary {
-        background: rgba(8, 47, 73, 0.35);
-        color: #e2f2ff;
-        border: 1px solid rgba(186, 230, 253, 0.4);
-    }
-
+    /* ---- Insight grid --------------------------------------------- */
     .insight-grid {
         display: grid;
         grid-template-columns: 1.05fr 0.95fr;
         gap: 1.5rem;
         margin-bottom: 2.5rem;
     }
-
     .intel-panel {
-        background: #ffffff;
-        border: 1px solid #dbeafe;
-        border-radius: 16px;
-        box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
-        padding: 1.3rem;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
+        padding: 1.4rem;
     }
-
     .panel-title {
         margin: 0;
-        font-size: 1.3rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        font-size: 1.5rem;
+        letter-spacing: 1px;
+        color: var(--accent);
+        border-bottom: none;
     }
+    .panel-subtitle { margin: 0.35rem 0 1.1rem 0; color: var(--muted); font-size: 0.9rem; }
 
-    .panel-subtitle {
-        margin: 0.35rem 0 1rem 0;
-        color: #64748b;
-        font-size: 0.95rem;
-    }
-
-    .correlation-list {
-        display: grid;
-        gap: 0.8rem;
-    }
-
+    .correlation-list { display: grid; gap: 0.7rem; }
     .correlation-item {
-        border: 1px solid #e2e8f0;
-        border-radius: 12px;
-        background: #f8fafc;
-        padding: 0.9rem 0.95rem;
+        border: 1px solid var(--border);
+        border-left: 2px solid rgba(255, 51, 102, 0.5);
+        border-radius: var(--border-radius);
+        background: var(--surface-2);
+        padding: 0.85rem 0.95rem;
     }
+    .correlation-head { display: flex; justify-content: space-between; align-items: baseline; gap: 0.75rem; margin-bottom: 0.3rem; }
+    .correlation-title { margin: 0; font-size: 0.95rem; color: var(--text); }
+    .correlation-metric { margin: 0; font-family: var(--font-mono); color: var(--accent2); font-weight: 700; font-size: 0.9rem; }
+    .correlation-detail { margin: 0; font-size: 0.84rem; color: var(--muted); }
 
-    .correlation-head {
-        display: flex;
-        justify-content: space-between;
-        align-items: baseline;
-        gap: 0.75rem;
-        margin-bottom: 0.3rem;
-    }
+    .signal-list { display: grid; gap: 0.7rem; }
+    .signal-row { border: 1px solid var(--border); border-radius: var(--border-radius); padding: 0.7rem 0.8rem; background: var(--surface-2); }
+    .signal-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 0.5rem; gap: 0.6rem; }
+    .signal-name { margin: 0; font-size: 0.88rem; color: var(--text); }
+    .signal-metric { margin: 0; font-family: var(--font-mono); font-size: 0.78rem; color: var(--accent3); font-weight: 500; }
+    .signal-bar { height: 6px; background: var(--surface-3); border-radius: 999px; overflow: hidden; }
+    .signal-bar-fill { height: 100%; background: linear-gradient(90deg, var(--accent-dim), var(--accent)); border-radius: 999px; box-shadow: 0 0 8px rgba(0,255,136,0.4); }
 
-    .correlation-title {
-        margin: 0;
-        font-size: 0.98rem;
-        color: #0f172a;
-    }
-
-    .correlation-metric {
-        margin: 0;
-        color: #0f766e;
-        font-weight: 700;
-        font-size: 0.94rem;
-    }
-
-    .correlation-detail {
-        margin: 0;
-        font-size: 0.86rem;
-        color: #475569;
-    }
-
-    .signal-list {
-        display: grid;
-        gap: 0.78rem;
-    }
-
-    .signal-row {
-        border: 1px solid #e2e8f0;
-        border-radius: 11px;
-        padding: 0.72rem 0.78rem;
-        background: #ffffff;
-    }
-
-    .signal-head {
-        display: flex;
-        justify-content: space-between;
-        align-items: baseline;
-        margin-bottom: 0.45rem;
-        gap: 0.6rem;
-    }
-
-    .signal-name {
-        margin: 0;
-        font-size: 0.9rem;
-        color: #0f172a;
-    }
-
-    .signal-metric {
-        margin: 0;
-        font-size: 0.82rem;
-        color: #0369a1;
-        font-weight: 600;
-    }
-
-    .signal-bar {
-        height: 7px;
-        background: #e2e8f0;
-        border-radius: 999px;
-        overflow: hidden;
-    }
-
-    .signal-bar-fill {
-        height: 100%;
-        background: linear-gradient(90deg, #0e7490, #0891b2);
-        border-radius: 999px;
-    }
-
-    .recent-activity {
-        margin-bottom: 2.8rem;
-    }
-
-    .section-header {
-        margin-bottom: 1.1rem;
-    }
-
+    /* ---- Recent activity ------------------------------------------ */
+    .recent-activity { margin-bottom: 2.8rem; }
+    .section-header { margin-bottom: 1.2rem; }
     .section-title {
         margin: 0;
-        font-size: clamp(1.4rem, 2.6vw, 1.95rem);
+        font-family: var(--font-display);
+        font-weight: 400;
+        font-size: clamp(1.6rem, 2.8vw, 2.2rem);
+        letter-spacing: 1.5px;
+        color: var(--text);
         border-bottom: none;
     }
+    .section-subtitle { margin-top: 0.35rem; color: var(--muted); font-size: 0.9rem; }
 
-    .section-subtitle {
-        margin-top: 0.35rem;
-        color: #64748b;
-        font-size: 0.95rem;
-    }
-
-    .timeline-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 0.9rem;
-        margin-bottom: 1.4rem;
-    }
-
+    .timeline-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 0.85rem; margin-bottom: 1.4rem; }
     .timeline-card {
-        background: #ffffff;
-        border: 1px solid #dbeafe;
-        border-radius: 12px;
-        padding: 0.9rem;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        padding: 0.95rem;
+        transition: border-color 0.18s ease;
     }
+    .timeline-card:hover { border-color: var(--accent); }
+    .timeline-date { font-family: var(--font-mono); font-size: 0.78rem; color: var(--accent); font-weight: 600; margin-bottom: 0.5rem; }
+    .timeline-metrics { display: flex; justify-content: space-between; gap: 0.6rem; margin-bottom: 0.5rem; }
+    .timeline-metrics span { font-family: var(--font-mono); font-size: 0.8rem; color: var(--text-soft); }
+    .timeline-rate-bar { height: 6px; border-radius: 999px; background: var(--surface-3); overflow: hidden; }
+    .timeline-rate-fill { height: 100%; border-radius: 999px; background: linear-gradient(90deg, var(--accent3), var(--accent)); }
 
-    .timeline-date {
-        font-size: 0.8rem;
-        color: #0f766e;
-        font-weight: 700;
-        margin-bottom: 0.45rem;
-    }
-
-    .timeline-metrics {
-        display: flex;
-        justify-content: space-between;
-        gap: 0.6rem;
-        margin-bottom: 0.5rem;
-    }
-
-    .timeline-metrics span {
-        font-size: 0.82rem;
-        color: #334155;
-    }
-
-    .timeline-rate-bar {
-        height: 7px;
-        border-radius: 999px;
-        background: #e2e8f0;
-        overflow: hidden;
-    }
-
-    .timeline-rate-fill {
-        height: 100%;
-        border-radius: 999px;
-        background: linear-gradient(90deg, #0284c7, #0ea5a4);
-    }
-
-    .activity-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-        gap: 0.95rem;
-    }
-
+    .activity-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 0.9rem; }
     .activity-card {
-        background: #ffffff;
-        border: 1px solid #dbeafe;
-        border-radius: 12px;
-        padding: 1rem;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        padding: 1.1rem;
+        transition: transform 0.2s ease, border-color 0.2s ease;
     }
+    .activity-card:hover { transform: translateY(-3px); border-color: var(--accent); }
+    .activity-date { font-family: var(--font-mono); color: var(--accent3); font-size: 0.8rem; font-weight: 600; margin-bottom: 0.4rem; }
+    .activity-title { font-size: 1rem; margin: 0 0 0.8rem 0; color: var(--text); }
+    .activity-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.45rem; margin-bottom: 0.8rem; }
+    .activity-stats .mini-stat { min-width: 0; width: 100%; flex: initial; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius); padding: 0.5rem; text-align: center; }
+    .activity-stats .mini-stat-value { display: block; font-family: var(--font-display); font-size: 1.3rem; color: var(--accent); }
+    .activity-stats .mini-stat-label { display: block; font-family: var(--font-mono); font-size: 0.62rem; color: var(--muted); text-transform: uppercase; letter-spacing: 1px; }
+    .view-report-btn { display: inline-flex; align-items: center; gap: 0.35rem; font-family: var(--font-mono); font-size: 0.82rem; font-weight: 600; color: var(--accent); }
+    .activity-actions { text-align: center; margin-top: 1.3rem; }
 
-    .activity-date {
-        color: #0369a1;
-        font-size: 0.82rem;
-        font-weight: 700;
-        margin-bottom: 0.4rem;
-    }
-
-    .activity-title {
-        font-size: 1.02rem;
-        margin: 0 0 0.7rem 0;
-    }
-
-    .activity-stats {
-        display: grid;
-        grid-template-columns: repeat(3, 1fr);
-        gap: 0.45rem;
-        margin-bottom: 0.75rem;
-    }
-
-    .activity-stats .mini-stat {
-        min-width: 0;
-        width: 100%;
-        flex: initial;
-        background: #f8fafc;
-        border-radius: 8px;
-        padding: 0.45rem;
-        text-align: center;
-    }
-
-    .activity-stats .mini-stat-value {
-        display: block;
-        font-size: 1.02rem;
-        color: #0f172a;
-        font-weight: 700;
-    }
-
-    .activity-stats .mini-stat-label {
-        display: block;
-        font-size: 0.7rem;
-        color: #64748b;
-        text-transform: uppercase;
-    }
-
-    .view-report-btn {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.35rem;
-        font-weight: 600;
-        color: #0e7490;
-    }
-
-    .activity-actions {
-        text-align: center;
-        margin-top: 1.1rem;
-    }
-
+    /* ---- Features ------------------------------------------------- */
     .features-section {
-        background: linear-gradient(160deg, #ecfeff 0%, #f8fafc 42%, #ecfeff 100%);
-        border: 1px solid #dbeafe;
-        border-radius: 16px;
-        padding: 1.45rem;
+        background: linear-gradient(160deg, var(--surface) 0%, var(--surface-2) 100%);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        padding: 1.6rem;
         margin-bottom: 2.4rem;
     }
-
-    .features-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 0.8rem;
-        margin-top: 0.95rem;
-    }
-
+    .features-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 0.85rem; margin-top: 1rem; }
     .feature-card {
-        border-radius: 11px;
-        background: #ffffff;
-        border: 1px solid #e2e8f0;
-        padding: 0.9rem;
+        border-radius: var(--border-radius);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-top: 2px solid rgba(0, 255, 136, 0.4);
+        padding: 1.05rem;
+        transition: border-color 0.18s ease, transform 0.18s ease;
     }
+    .feature-card:hover { border-color: var(--accent); transform: translateY(-2px); }
+    .feature-title { margin: 0 0 0.4rem 0; font-family: var(--font-mono); font-size: 0.9rem; letter-spacing: 0.5px; color: var(--accent); border-bottom: none; }
+    .feature-description { margin: 0; font-size: 0.86rem; color: var(--muted); }
 
-    .feature-title {
-        margin: 0 0 0.35rem 0;
-        font-size: 1rem;
-        border-bottom: none;
-    }
-
-    .feature-description {
-        margin: 0;
-        font-size: 0.88rem;
-        color: #475569;
-    }
-
+    /* ---- CTA ------------------------------------------------------ */
     .cta-section {
-        background: #0f172a;
-        border-radius: 16px;
-        padding: 1.5rem;
-        color: #e2e8f0;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        border-radius: var(--border-radius);
+        padding: 1.75rem;
+        color: var(--text-soft);
         margin-bottom: 0.5rem;
     }
-
     .cta-section h2 {
-        color: #f8fafc;
+        color: var(--text);
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
         margin: 0 0 0.65rem 0;
         border-bottom: none;
     }
+    .cta-section p { color: var(--muted); margin-bottom: 1.2rem; }
 
-    .cta-section p {
-        color: #cbd5e1;
-        margin-bottom: 1rem;
-    }
-
-    @media (max-width: 980px) {
-        .insight-grid {
-            grid-template-columns: 1fr;
-        }
-    }
-
+    @media (max-width: 980px) { .insight-grid { grid-template-columns: 1fr; } }
     @media (max-width: 768px) {
-        .intel-hero {
-            padding: 2.3rem 1.2rem;
-        }
-
-        .activity-stats {
-            grid-template-columns: 1fr;
-        }
+        .intel-hero { padding: 2.3rem 1.2rem; }
+        .activity-stats { grid-template-columns: 1fr; }
     }
 </style>
 
@@ -515,7 +341,7 @@
 <section class="intel-hero">
     <div class="intel-hero-content">
         <div class="hero-kicker">Live Threat Surface</div>
-        <h1 class="hero-title">ClickGrab Threat Intelligence, rebuilt for speed and clarity</h1>
+        <h1 class="hero-title">ClickGrab Threat Intelligence</h1>
         <p class="hero-subtitle">
             Daily telemetry from ClickFix and FakeCAPTCHA campaigns, correlated into one view so teams can spot the chain:
             social lure, clipboard abuse, and execution behavior.

--- a/docs/mitigations.html
+++ b/docs/mitigations.html
@@ -5,231 +5,270 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mitigations - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .mitigations-header {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .mitigations-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .mitigations-subtitle {
         font-size: 1.2rem;
-        color: rgba(255, 255, 255, 0.9);
+        color: var(--text-soft);
         max-width: 600px;
         margin: 0 auto;
         line-height: 1.6;
     }
-    
+
     .mitigation-section {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
         margin-bottom: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
     }
-    
+
     .mitigation-section h2 {
-        color: #333;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin-bottom: 1.5rem;
         font-size: 1.8rem;
         display: flex;
         align-items: center;
         gap: 0.5rem;
     }
-    
+
+    .mitigation-section h2 i {
+        color: var(--accent);
+    }
+
     .mitigation-section h3 {
-        color: #555;
+        color: var(--text-soft);
         margin-bottom: 1rem;
         font-size: 1.3rem;
         margin-top: 2rem;
     }
-    
+
     .mitigation-section h3:first-child {
         margin-top: 0;
     }
-    
+
+    .mitigation-section p,
+    .mitigation-section li {
+        color: var(--text-soft);
+    }
+
+    .mitigation-section a {
+        color: var(--accent3);
+        text-decoration: none;
+    }
+
+    .mitigation-section a:hover {
+        color: var(--accent);
+        text-decoration: underline;
+    }
+
     .code-block {
-        background: #f8f9fa;
-        border: 1px solid #e9ecef;
-        border-radius: 8px;
+        background: #05050a;
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
+        border-radius: var(--border-radius);
         padding: 1.5rem;
         margin: 1rem 0;
-        font-family: 'Courier New', monospace;
+        font-family: var(--font-mono);
         font-size: 0.9rem;
         line-height: 1.5;
+        color: var(--accent3);
         overflow-x: auto;
     }
-    
+
     .warning-box {
-        background: #fff3cd;
-        border: 1px solid #ffeaa7;
-        border-radius: 8px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 1rem;
         margin: 1rem 0;
-        border-left: 4px solid #f39c12;
+        border-left: 3px solid var(--accent4);
+        color: var(--text-soft);
     }
-    
+
     .info-box {
-        background: #d1ecf1;
-        border: 1px solid #bee5eb;
-        border-radius: 8px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 1rem;
         margin: 1rem 0;
-        border-left: 4px solid #17a2b8;
+        border-left: 3px solid var(--accent3);
+        color: var(--text-soft);
     }
-    
+
     .tool-card {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface-2);
+        border-radius: var(--border-radius);
         padding: 1.5rem;
         margin: 1rem 0;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-        border: 1px solid #e1e5e9;
-        transition: transform 0.2s ease, box-shadow 0.2s ease;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        transition: transform 0.18s ease, border-color 0.18s ease;
     }
-    
+
     .tool-card:hover {
         transform: translateY(-2px);
-        box-shadow: 0 4px 20px rgba(0,0,0,0.15);
+        border-color: var(--accent);
     }
-    
+
     .tool-header {
         display: flex;
         align-items: center;
         gap: 1rem;
         margin-bottom: 1rem;
     }
-    
+
     .tool-icon {
         width: 48px;
         height: 48px;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        border-radius: 12px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         display: flex;
         align-items: center;
         justify-content: center;
-        color: white;
+        color: var(--accent);
         font-size: 1.5rem;
     }
-    
+
     .tool-title {
+        font-family: var(--font-display);
         font-size: 1.3rem;
-        font-weight: 600;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .tool-description {
-        color: #666;
+        color: var(--text-soft);
         line-height: 1.6;
         margin-bottom: 1rem;
     }
-    
+
     .tool-links {
         display: flex;
         gap: 1rem;
         flex-wrap: wrap;
     }
-    
+
     .tool-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: #f8f9fa;
-        border: 1px solid #e9ecef;
-        border-radius: 6px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         text-decoration: none;
-        color: #495057;
+        color: var(--text-soft);
+        font-family: var(--font-mono);
         font-size: 0.9rem;
-        transition: all 0.2s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .tool-link:hover {
-        background: #e9ecef;
-        color: #333;
+        background: var(--surface-3);
+        border-color: var(--accent);
+        color: var(--accent);
         text-decoration: none;
     }
-    
+
     .tool-link.github {
-        background: #24292e;
-        color: white;
-        border-color: #24292e;
+        background: var(--surface-3);
+        color: var(--text);
+        border-color: var(--border);
     }
-    
+
     .tool-link.github:hover {
-        background: #1a1e22;
-        color: white;
+        border-color: var(--accent);
+        color: var(--accent);
     }
-    
+
     .contributor-info {
-        background: #f8f9fa;
-        border-radius: 8px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 1rem;
         margin: 1rem 0;
-        border-left: 4px solid #28a745;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .contributor-name {
+        font-family: var(--font-mono);
         font-weight: 600;
-        color: #28a745;
+        letter-spacing: 0.5px;
+        color: var(--accent);
         margin-bottom: 0.5rem;
     }
-    
+
     .contributor-links {
         display: flex;
         gap: 1rem;
         flex-wrap: wrap;
     }
-    
+
     .contributor-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
+        font-family: var(--font-mono);
         font-size: 0.9rem;
     }
-    
+
     .contributor-link:hover {
+        color: var(--accent);
         text-decoration: underline;
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
+        font-family: var(--font-mono);
         font-weight: 500;
+        letter-spacing: 0.5px;
         margin-bottom: 2rem;
-        transition: color 0.2s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .back-link:hover {
-        color: #5a6fd8;
+        color: var(--accent);
         text-decoration: none;
     }
     

--- a/docs/reports.html
+++ b/docs/reports.html
@@ -5,29 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ClickGrab - Threat Intelligence Reports Archive</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <style>
     /* Page Header */
     .reports-hero {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 4rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
         position: relative;
         overflow: hidden;
+        box-shadow: var(--shadow);
     }
-    
+
     .reports-hero::after {
         content: '';
         position: absolute;
@@ -35,25 +35,27 @@
         left: 0;
         right: 0;
         height: 100px;
-        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 320"><path fill="rgba(255,255,255,0.1)" d="M0,96L48,112C96,128,192,160,288,165.3C384,171,480,149,576,138.7C672,128,768,128,864,144C960,160,1056,192,1152,186.7C1248,181,1344,139,1392,117.3L1440,96L1440,320L1392,320C1344,320,1248,320,1152,320C1056,320,960,320,864,320C768,320,672,320,576,320C480,320,384,320,288,320C192,320,96,320,48,320L0,320Z"></path></svg>') no-repeat;
+        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 320"><path fill="rgba(0,255,136,0.06)" d="M0,96L48,112C96,128,192,160,288,165.3C384,171,480,149,576,138.7C672,128,768,128,864,144C960,160,1056,192,1152,186.7C1248,181,1344,139,1392,117.3L1440,96L1440,320L1392,320C1344,320,1248,320,1152,320C1056,320,960,320,864,320C768,320,672,320,576,320C480,320,384,320,288,320C192,320,96,320,48,320L0,320Z"></path></svg>') no-repeat;
         background-size: cover;
         pointer-events: none;
     }
-    
+
     .reports-hero h1 {
+        font-family: var(--font-display);
         font-size: 2.5rem;
         margin-bottom: 1rem;
-        font-weight: 700;
+        font-weight: 400;
+        letter-spacing: 2px;
+        color: var(--accent);
     }
-    
+
     .reports-hero p {
         font-size: 1.2rem;
-        color: rgba(255, 255, 255, 0.95);
+        color: var(--text-soft);
         max-width: 600px;
         margin: 0 auto;
-        text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
     }
-    
+
     /* Stats Summary */
     .reports-summary {
         display: grid;
@@ -62,93 +64,108 @@
         max-width: 600px;
         margin: 2rem auto 0;
     }
-    
+
     .summary-stat {
-        background: rgba(255,255,255,0.1);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         text-align: center;
     }
-    
+
     .summary-stat-value {
+        font-family: var(--font-mono);
         font-size: 2rem;
         font-weight: 700;
         display: block;
+        color: var(--accent);
     }
-    
+
     .summary-stat-label {
+        font-family: var(--font-mono);
         font-size: 0.85rem;
-        opacity: 0.9;
+        color: var(--muted);
         text-transform: uppercase;
         letter-spacing: 0.5px;
     }
-    
+
     /* Executive Summary & Key Findings */
     .executive-section {
-        background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
-        border-radius: 16px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 2rem;
         margin-bottom: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border: 1px solid #e2e8f0;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .executive-header {
         display: flex;
         align-items: center;
         gap: 1rem;
         margin-bottom: 1.5rem;
     }
-    
+
     .executive-icon {
         width: 48px;
         height: 48px;
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        border-radius: 12px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         display: flex;
         align-items: center;
         justify-content: center;
         font-size: 24px;
         flex-shrink: 0;
     }
-    
+
     .executive-title {
+        font-family: var(--font-display);
         font-size: 1.75rem;
-        font-weight: 700;
-        color: var(--text-color);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
     }
-    
+
     .executive-content {
-        color: var(--text-light);
+        color: var(--text-soft);
         line-height: 1.8;
         font-size: 1.05rem;
     }
-    
+
     .key-findings {
-        background: white;
-        border-radius: 16px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 2rem;
         margin-bottom: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border: 1px solid #e2e8f0;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
     }
-    
+
     .findings-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
         gap: 1.5rem;
         margin-top: 1.5rem;
     }
-    
+
     .finding-card {
-        background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+        background: var(--surface-2);
         padding: 1.5rem;
-        border-radius: 12px;
-        border: 1px solid #e2e8f0;
+        border-radius: var(--border-radius);
+        border: 1px solid var(--border);
         position: relative;
         overflow: hidden;
+        transition: all 0.18s ease;
     }
-    
+
+    .finding-card:hover {
+        transform: translateY(-2px);
+        border-color: var(--accent);
+    }
+
     .finding-card::before {
         content: '';
         position: absolute;
@@ -156,152 +173,163 @@
         left: 0;
         width: 4px;
         height: 100%;
-        background: linear-gradient(180deg, #0e7490, #0f766e);
+        background: var(--accent);
     }
-    
+
     .finding-icon {
         width: 40px;
         height: 40px;
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        border-radius: 10px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         display: flex;
         align-items: center;
         justify-content: center;
         margin-bottom: 1rem;
         font-size: 20px;
     }
-    
+
     .finding-title {
         font-size: 1.1rem;
         font-weight: 600;
-        color: var(--text-color);
+        color: var(--text);
         margin-bottom: 0.5rem;
     }
-    
+
     .finding-value {
+        font-family: var(--font-mono);
         font-size: 2rem;
         font-weight: 700;
-        color: #0e7490;
+        color: var(--accent);
         margin-bottom: 0.5rem;
     }
-    
+
     .finding-desc {
         font-size: 0.9rem;
-        color: var(--text-light);
+        color: var(--muted);
         line-height: 1.5;
     }
-    
+
     .finding-trend {
         display: inline-flex;
         align-items: center;
         gap: 0.25rem;
+        font-family: var(--font-mono);
         font-size: 0.85rem;
         font-weight: 600;
         margin-top: 0.5rem;
     }
-    
+
     .trend-up {
-        color: #ef4444;
+        color: var(--accent2);
     }
-    
+
     .trend-down {
-        color: #22c55e;
+        color: var(--accent);
     }
-    
+
     /* Table of Contents */
     .toc-section {
-        background: white;
-        border-radius: 16px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 2rem;
         margin-bottom: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border: 1px solid #e2e8f0;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .toc-header {
         display: flex;
         align-items: center;
         gap: 1rem;
         margin-bottom: 1.5rem;
     }
-    
+
     .toc-grid {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
         gap: 1rem;
     }
-    
+
     .toc-item {
-        background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         text-decoration: none;
-        color: var(--text-color);
-        transition: all 0.3s ease;
-        border: 1px solid #e2e8f0;
+        color: var(--text);
+        transition: all 0.18s ease;
+        border: 1px solid var(--border);
         display: flex;
         flex-direction: column;
         gap: 0.25rem;
     }
-    
+
     .toc-item:hover {
-        transform: translateY(-3px);
-        box-shadow: 0 8px 20px rgba(0,0,0,0.12);
-        border-color: #0e7490;
-        color: var(--text-color);
+        transform: translateY(-2px);
+        box-shadow: var(--shadow);
+        border-color: var(--accent);
+        color: var(--text);
     }
-    
+
     .toc-month {
         font-weight: 600;
         font-size: 1.1rem;
+        color: var(--text);
     }
-    
+
     .toc-stats {
+        font-family: var(--font-mono);
         font-size: 0.85rem;
-        color: var(--text-light);
+        color: var(--muted);
     }
-    
+
     .toc-highlight {
+        font-family: var(--font-mono);
         font-size: 0.75rem;
-        color: #0e7490;
+        color: var(--accent);
         font-weight: 500;
     }
-    
+
     /* Month Groups */
     .month-section {
         margin-bottom: 3rem;
         scroll-margin-top: 80px;
     }
-    
+
     .month-header {
         display: flex;
         align-items: center;
         justify-content: space-between;
         margin-bottom: 1.5rem;
         padding-bottom: 0.75rem;
-        border-bottom: 2px solid #e5e7eb;
+        border-bottom: 2px solid var(--accent);
     }
-    
+
     .month-title {
+        font-family: var(--font-display);
         font-size: 1.75rem;
-        font-weight: 600;
-        color: var(--text-color);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
     }
-    
+
     .month-stats {
         display: flex;
         gap: 1.5rem;
+        font-family: var(--font-mono);
         font-size: 0.9rem;
-        color: var(--text-light);
+        color: var(--muted);
     }
-    
+
     /* Back to Top Button */
     .back-to-top {
         position: fixed;
         bottom: 2rem;
         right: 2rem;
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        color: white;
+        background: var(--surface-2);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         width: 48px;
         height: 48px;
         border-radius: 50%;
@@ -309,246 +337,273 @@
         align-items: center;
         justify-content: center;
         text-decoration: none;
-        box-shadow: 0 4px 20px rgba(102, 126, 234, 0.4);
-        transition: all 0.3s ease;
+        box-shadow: var(--shadow);
+        transition: all 0.18s ease;
         opacity: 0;
         pointer-events: none;
         z-index: 100;
     }
-    
+
     .back-to-top.visible {
         opacity: 1;
         pointer-events: all;
     }
-    
+
     .back-to-top:hover {
-        transform: translateY(-3px);
-        box-shadow: 0 8px 30px rgba(102, 126, 234, 0.5);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--surface-3);
+        box-shadow: var(--shadow);
+        color: var(--accent);
     }
-    
+
     /* Report Cards */
     .reports-grid {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
         gap: 1.5rem;
     }
-    
+
     .report-card {
-        background: white;
-        border-radius: 12px;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.08);
+        background: var(--surface);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
         overflow: hidden;
-        transition: all 0.3s ease;
-        border: 1px solid #e5e7eb;
+        transition: all 0.18s ease;
+        border: 1px solid var(--border);
         position: relative;
     }
-    
+
     .report-card:hover {
-        transform: translateY(-5px);
-        box-shadow: 0 8px 25px rgba(0,0,0,0.12);
-        border-color: #0e7490;
+        transform: translateY(-2px);
+        box-shadow: var(--shadow);
+        border-color: var(--accent);
     }
-    
+
     .report-header {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-2);
+        border-bottom: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 1.25rem;
         position: relative;
     }
-    
+
     .report-date {
+        font-family: var(--font-mono);
         font-size: 0.85rem;
-        opacity: 1;
-        color: #FFFFFF !important;
+        color: var(--muted) !important;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
         margin-bottom: 0.25rem;
     }
-    
+
     .report-title {
         font-size: 1.25rem;
         font-weight: 600;
         margin: 0;
+        color: var(--text);
     }
-    
+
     .threat-badge {
         position: absolute;
         top: 1rem;
         right: 1rem;
         padding: 0.25rem 0.75rem;
-        border-radius: 20px;
+        border-radius: var(--border-radius);
+        font-family: var(--font-mono);
         font-size: 0.75rem;
         font-weight: 600;
-        background: rgba(255,255,255,0.2);
-        backdrop-filter: blur(5px);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
-    
+
     .threat-badge.high {
-        background: rgba(239, 68, 68, 0.9);
+        background: rgba(255, 51, 102, 0.15);
+        border-color: var(--accent2);
+        color: var(--accent2);
     }
-    
+
     .threat-badge.medium {
-        background: rgba(245, 158, 11, 0.9);
+        background: rgba(255, 204, 0, 0.12);
+        border-color: var(--accent4);
+        color: var(--accent4);
     }
-    
+
     .threat-badge.low {
-        background: rgba(34, 197, 94, 0.9);
+        background: rgba(0, 255, 136, 0.12);
+        border-color: var(--accent);
+        color: var(--accent);
     }
-    
+
     .report-body {
         padding: 1.5rem;
     }
-    
+
     .report-metrics {
         display: grid;
         grid-template-columns: repeat(2, 1fr);
         gap: 1rem;
         margin-bottom: 1.5rem;
     }
-    
+
     .metric {
         text-align: center;
         padding: 0.75rem;
-        background: #f9fafb;
-        border-radius: 8px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .metric-value {
+        font-family: var(--font-mono);
         font-size: 1.5rem;
         font-weight: 700;
-        color: #0e7490;
+        color: var(--accent);
         display: block;
     }
-    
+
     .metric-label {
+        font-family: var(--font-mono);
         font-size: 0.75rem;
-        color: var(--text-light);
+        color: var(--muted);
         text-transform: uppercase;
         letter-spacing: 0.5px;
     }
-    
+
     .report-highlights {
         margin-bottom: 1.5rem;
     }
-    
+
     .highlight-item {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         margin-bottom: 0.5rem;
         font-size: 0.9rem;
-        color: var(--text-color);
+        color: var(--text-soft);
     }
-    
+
     .highlight-icon {
-        color: #0e7490;
+        color: var(--accent);
         flex-shrink: 0;
     }
-    
+
     .view-report-link {
         display: block;
         text-align: center;
-        background: #0e7490;
-        color: white;
+        background: var(--accent);
+        color: var(--bg);
         padding: 0.75rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         text-decoration: none;
+        font-family: var(--font-mono);
         font-weight: 600;
-        transition: background 0.2s ease;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        transition: all 0.18s ease;
     }
-    
+
     .view-report-link:hover {
-        background: #5a5fbf;
-        color: white;
+        background: var(--accent-dim);
+        color: var(--bg);
     }
-    
+
     /* Filters */
     .filters-section {
-        background: white;
+        background: var(--surface);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.08);
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
     }
-    
+
     .filters-row {
         display: flex;
         gap: 1rem;
         flex-wrap: wrap;
         align-items: center;
     }
-    
+
     .filter-group {
         flex: 1;
         min-width: 200px;
     }
-    
+
     .filter-label {
         display: block;
         margin-bottom: 0.5rem;
+        font-family: var(--font-mono);
         font-size: 0.9rem;
         font-weight: 500;
-        color: var(--text-color);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        color: var(--muted);
     }
-    
+
     .filter-select {
         width: 100%;
         padding: 0.5rem 1rem;
-        border: 1px solid #e5e7eb;
-        border-radius: 8px;
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         font-size: 0.95rem;
-        background: white;
-        transition: border-color 0.2s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        transition: border-color 0.18s ease;
     }
-    
+
     .filter-select:focus {
         outline: none;
-        border-color: #0e7490;
+        border-color: var(--accent);
     }
-    
+
     /* Empty State */
     .empty-state {
         text-align: center;
         padding: 4rem 2rem;
-        color: var(--text-light);
+        color: var(--muted);
     }
-    
+
     .empty-state-icon {
         font-size: 3rem;
         margin-bottom: 1rem;
         opacity: 0.5;
     }
-    
+
     /* Responsive */
     @media (max-width: 768px) {
         .reports-hero h1 {
             font-size: 2rem;
         }
-        
+
         .reports-grid {
             grid-template-columns: 1fr;
         }
-        
+
         .month-header {
             flex-direction: column;
             gap: 1rem;
             align-items: flex-start;
         }
-        
+
         .filters-row {
             flex-direction: column;
         }
-        
+
         .filter-group {
             width: 100%;
         }
     }
-    
+
     /* Loading Animation */
     .loading {
         opacity: 0.6;
         pointer-events: none;
     }
-    
+
     .loading::after {
         content: '';
         position: absolute;
@@ -557,12 +612,12 @@
         width: 40px;
         height: 40px;
         margin: -20px 0 0 -20px;
-        border: 3px solid #f3f3f3;
-        border-top: 3px solid #0e7490;
+        border: 3px solid var(--border);
+        border-top: 3px solid var(--accent);
         border-radius: 50%;
         animation: spin 1s linear infinite;
     }
-    
+
     @keyframes spin {
         0% { transform: rotate(0deg); }
         100% { transform: rotate(360deg); }
@@ -1905,66 +1960,6 @@
             </div>
             
             <div class="report-card" 
-                 data-threats="42"
-                 data-powershell="19"
-                 data-high-risk="20"
-                 data-score="0">
-                
-                <div class="report-header">
-                    <div class="report-date">May 12, 2026</div>
-                    <h3 class="report-title">Daily Threat Report</h3>
-                    
-                    
-                    <span class="threat-badge high">High Threat</span>
-                    
-                </div>
-                
-                <div class="report-body">
-                    <div class="report-metrics">
-                        <div class="metric">
-                            <span class="metric-value">42</span>
-                            <span class="metric-label">Threats</span>
-                        </div>
-                        <div class="metric">
-                            <span class="metric-value">100</span>
-                            <span class="metric-label">Sites</span>
-                        </div>
-                        <div class="metric">
-                            <span class="metric-value">0</span>
-                            <span class="metric-label">Avg Score</span>
-                        </div>
-                        <div class="metric">
-                            <span class="metric-value">42.0%</span>
-                            <span class="metric-label">Detection</span>
-                        </div>
-                    </div>
-                    
-                    <div class="report-highlights">
-                        
-                        <div class="highlight-item">
-                            <span class="highlight-icon">💻</span>
-                            <span>19 PowerShell commands</span>
-                        </div>
-                        
-                        
-                        <div class="highlight-item">
-                            <span class="highlight-icon">⚠️</span>
-                            <span>20 high-risk commands</span>
-                        </div>
-                        
-                        <div class="highlight-item">
-                            <span class="highlight-icon">🎯</span>
-                            <span>Automated threat detection</span>
-                        </div>
-                    </div>
-                    
-                    <a href="/ClickGrab/reports/2026-05-12.html" class="view-report-link">
-                        View Detailed Analysis
-                    </a>
-                </div>
-            </div>
-            
-            <div class="report-card" 
                  data-threats="43"
                  data-powershell="19"
                  data-high-risk="21"
@@ -2019,6 +2014,66 @@
                     </div>
                     
                     <a href="/ClickGrab/reports/2026-05-13.html" class="view-report-link">
+                        View Detailed Analysis
+                    </a>
+                </div>
+            </div>
+            
+            <div class="report-card" 
+                 data-threats="42"
+                 data-powershell="19"
+                 data-high-risk="20"
+                 data-score="0">
+                
+                <div class="report-header">
+                    <div class="report-date">May 12, 2026</div>
+                    <h3 class="report-title">Daily Threat Report</h3>
+                    
+                    
+                    <span class="threat-badge high">High Threat</span>
+                    
+                </div>
+                
+                <div class="report-body">
+                    <div class="report-metrics">
+                        <div class="metric">
+                            <span class="metric-value">42</span>
+                            <span class="metric-label">Threats</span>
+                        </div>
+                        <div class="metric">
+                            <span class="metric-value">100</span>
+                            <span class="metric-label">Sites</span>
+                        </div>
+                        <div class="metric">
+                            <span class="metric-value">0</span>
+                            <span class="metric-label">Avg Score</span>
+                        </div>
+                        <div class="metric">
+                            <span class="metric-value">42.0%</span>
+                            <span class="metric-label">Detection</span>
+                        </div>
+                    </div>
+                    
+                    <div class="report-highlights">
+                        
+                        <div class="highlight-item">
+                            <span class="highlight-icon">💻</span>
+                            <span>19 PowerShell commands</span>
+                        </div>
+                        
+                        
+                        <div class="highlight-item">
+                            <span class="highlight-icon">⚠️</span>
+                            <span>20 high-risk commands</span>
+                        </div>
+                        
+                        <div class="highlight-item">
+                            <span class="highlight-icon">🎯</span>
+                            <span>Automated threat detection</span>
+                        </div>
+                    </div>
+                    
+                    <a href="/ClickGrab/reports/2026-05-12.html" class="view-report-link">
                         View Detailed Analysis
                     </a>
                 </div>

--- a/docs/reports/2026-05-30.html
+++ b/docs/reports/2026-05-30.html
@@ -5,28 +5,28 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ClickGrab Report - May 30, 2026</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <style>
     /* Report Header */
     .report-hero {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         position: relative;
         overflow: hidden;
+        box-shadow: var(--shadow);
     }
-    
+
     .report-hero::before {
         content: '';
         position: absolute;
@@ -34,27 +34,31 @@
         left: 0;
         right: 0;
         bottom: 0;
-        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><pattern id="grid" width="10" height="10" patternUnits="userSpaceOnUse"><path d="M 10 0 L 0 0 0 10" fill="none" stroke="rgba(255,255,255,0.1)" stroke-width="0.5"/></pattern><rect width="100" height="100" fill="url(%23grid)"/></svg>');
-        opacity: 0.3;
+        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><pattern id="grid" width="10" height="10" patternUnits="userSpaceOnUse"><path d="M 10 0 L 0 0 0 10" fill="none" stroke="rgba(0,255,136,0.06)" stroke-width="0.5"/></pattern><rect width="100" height="100" fill="url(%23grid)"/></svg>');
+        opacity: 0.5;
     }
-    
+
     .report-hero-content {
         position: relative;
         z-index: 1;
     }
-    
+
     .report-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 700;
+        font-weight: 400;
+        letter-spacing: 2px;
+        color: var(--accent);
         margin-bottom: 1rem;
     }
-    
+
     .report-meta {
         display: flex;
         gap: 2rem;
         flex-wrap: wrap;
-        font-size: 1.1rem;
-        opacity: 0.95;
+        font-family: var(--font-mono);
+        font-size: 0.95rem;
+        color: var(--text-soft);
     }
     
     /* Summary Cards */
@@ -66,78 +70,82 @@
     }
     
     .summary-card {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 1.5rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+        box-shadow: var(--shadow);
         text-align: center;
-        transition: transform 0.3s ease;
-        border: 1px solid #e5e7eb;
+        transition: transform 0.18s ease, border-color 0.18s ease;
+        border: 1px solid var(--border);
         position: relative;
         overflow: hidden;
     }
-    
+
     .summary-card::before {
         content: '';
         position: absolute;
         top: 0;
         left: 0;
         right: 0;
-        height: 4px;
-        background: linear-gradient(90deg, var(--gradient-start), var(--gradient-end));
+        height: 3px;
+        background: var(--accent-edge, var(--accent));
     }
-    
-    .summary-card.total { --gradient-start: #0e7490; --gradient-end: #0f766e; }
-    .summary-card.threats { --gradient-start: #22c55e; --gradient-end: #0891b2; }
-    .summary-card.powershell { --gradient-start: #4facfe; --gradient-end: #00f2fe; }
-    .summary-card.clipboard { --gradient-start: #fa709a; --gradient-end: #fee140; }
-    .summary-card.score { --gradient-start: #30cfd0; --gradient-end: #330867; }
-    
+
+    .summary-card.total { --accent-edge: var(--accent3); }
+    .summary-card.threats { --accent-edge: var(--accent2); }
+    .summary-card.powershell { --accent-edge: var(--accent3); }
+    .summary-card.clipboard { --accent-edge: var(--accent4); }
+    .summary-card.score { --accent-edge: var(--accent); }
+
     .summary-card:hover {
-        transform: translateY(-5px);
-        box-shadow: 0 8px 30px rgba(0,0,0,0.12);
+        transform: translateY(-2px);
+        border-color: var(--accent);
     }
-    
+
     .summary-icon {
         font-size: 2.5rem;
         margin-bottom: 1rem;
     }
-    
+
     .summary-value {
+        font-family: var(--font-mono);
         font-size: 2.5rem;
         font-weight: 700;
-        color: var(--text-color);
+        color: var(--text);
         margin-bottom: 0.5rem;
     }
-    
+
     .summary-label {
-        color: var(--text-light);
+        font-family: var(--font-mono);
+        color: var(--muted);
         font-size: 0.9rem;
         text-transform: uppercase;
         letter-spacing: 0.5px;
     }
-    
+
     .summary-change {
         margin-top: 0.5rem;
+        font-family: var(--font-mono);
         font-size: 0.85rem;
         display: flex;
         align-items: center;
         justify-content: center;
         gap: 0.25rem;
     }
-    
-    .change-up { color: #ef4444; }
-    .change-down { color: #22c55e; }
+
+    .change-up { color: var(--accent2); }
+    .change-down { color: var(--accent); }
     
     /* Threat Overview */
     .threat-overview {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
         margin-bottom: 3rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+        box-shadow: var(--shadow);
     }
-    
+
     .threat-header {
         display: flex;
         justify-content: space-between;
@@ -146,33 +154,36 @@
         flex-wrap: wrap;
         gap: 1rem;
     }
-    
+
     .threat-title {
+        font-family: var(--font-display);
         font-size: 1.75rem;
-        font-weight: 600;
-        color: var(--text-color);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
     }
-    
+
     .threat-actions {
         display: flex;
         gap: 1rem;
     }
-    
+
     .action-btn {
         padding: 0.5rem 1rem;
-        border: 1px solid #e5e7eb;
-        border-radius: 8px;
-        background: white;
-        color: var(--text-color);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        background: var(--surface-2);
+        color: var(--text-soft);
+        font-family: var(--font-mono);
         font-size: 0.9rem;
         cursor: pointer;
-        transition: all 0.2s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .action-btn:hover {
-        background: #f9fafb;
-        border-color: #0e7490;
-        color: #0e7490;
+        background: var(--surface-3);
+        border-color: var(--accent);
+        color: var(--accent);
     }
 
     /* Simple bar chart styles */
@@ -183,14 +194,14 @@
         margin-top: 1rem;
     }
     .bar {
-        background: #f9fafb;
-        border: 1px solid #e5e7eb;
-        border-radius: 8px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 0.75rem;
     }
-    .bar-label { font-size: 0.9rem; color: var(--text-light); }
-    .bar-track { height: 10px; background: #eef2ff; border-radius: 6px; margin-top: 0.5rem; overflow: hidden; }
-    .bar-fill { height: 100%; background: linear-gradient(90deg,#0e7490,#0f766e); border-radius: 6px; width: 0%; transition: width .6s ease; }
+    .bar-label { font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted); }
+    .bar-track { height: 10px; background: var(--surface-3); border-radius: 6px; margin-top: 0.5rem; overflow: hidden; }
+    .bar-fill { height: 100%; background: var(--accent); border-radius: 6px; width: 0%; transition: width .6s ease; }
     
     /* Site Analysis Cards */
     .sites-section {
@@ -205,27 +216,27 @@
     }
     
     .site-card {
-        background: white;
-        border-radius: 12px;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.08);
+        background: var(--surface);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
         margin-bottom: 1.5rem;
         overflow: hidden;
-        transition: all 0.3s ease;
-        border: 1px solid #e5e7eb;
+        transition: all 0.18s ease;
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
     }
-    
+
     .site-card:hover {
-        box-shadow: 0 4px 20px rgba(0,0,0,0.12);
-        border-color: #0e7490;
+        border-color: var(--accent);
     }
-    
+
     .site-header {
-        background: #f9fafb;
+        background: var(--surface-2);
         padding: 1.5rem;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--border);
         cursor: pointer;
     }
-    
+
     .site-header-content {
         display: flex;
         justify-content: space-between;
@@ -233,41 +244,44 @@
         flex-wrap: wrap;
         gap: 1rem;
     }
-    
+
     .site-url {
         font-weight: 600;
-        color: #ef4444;
+        color: var(--accent2);
         word-break: break-all;
-        font-family: monospace;
+        font-family: var(--font-mono);
         font-size: 0.95rem;
     }
-    
+
     .site-badges {
         display: flex;
         gap: 0.5rem;
         flex-wrap: wrap;
     }
-    
+
     .threat-score-badge {
         padding: 0.25rem 0.75rem;
         border-radius: 20px;
+        font-family: var(--font-mono);
         font-size: 0.8rem;
         font-weight: 600;
-        color: white;
+        color: var(--bg);
     }
-    
-    .score-critical { background: #dc2626; }
-    .score-high { background: #ef4444; }
-    .score-medium { background: #f59e0b; }
-    .score-low { background: #3b82f6; }
-    
+
+    .score-critical { background: var(--accent2); }
+    .score-high { background: var(--accent2); }
+    .score-medium { background: var(--accent4); }
+    .score-low { background: var(--accent); }
+
     .attack-type-badge {
         padding: 0.25rem 0.75rem;
         border-radius: 20px;
+        font-family: var(--font-mono);
         font-size: 0.8rem;
         font-weight: 500;
-        background: #e0e7ff;
-        color: #4c1d95;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent3);
     }
     
     .site-details {
@@ -283,28 +297,29 @@
         display: flex;
         gap: 1rem;
         margin-bottom: 1.5rem;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--border);
     }
-    
+
     .detail-tab {
         padding: 0.5rem 1rem;
         border: none;
         background: none;
-        color: var(--text-light);
+        color: var(--muted);
+        font-family: var(--font-mono);
         font-weight: 500;
         cursor: pointer;
         position: relative;
-        transition: color 0.2s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .detail-tab:hover {
-        color: var(--text-color);
+        color: var(--text);
     }
-    
+
     .detail-tab.active {
-        color: #0e7490;
+        color: var(--accent);
     }
-    
+
     .detail-tab.active::after {
         content: '';
         position: absolute;
@@ -312,7 +327,7 @@
         left: 0;
         right: 0;
         height: 2px;
-        background: #0e7490;
+        background: var(--accent);
     }
     
     .tab-content {
@@ -332,132 +347,152 @@
         font-size: 1.1rem;
         font-weight: 600;
         margin-bottom: 1rem;
-        color: var(--text-color);
+        color: var(--text);
         display: flex;
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .indicator-count {
-        background: #e0e7ff;
-        color: #4c1d95;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent3);
         padding: 0.125rem 0.5rem;
         border-radius: 12px;
+        font-family: var(--font-mono);
         font-size: 0.8rem;
         font-weight: 500;
     }
-    
+
     .indicator-list {
-        background: #f9fafb;
-        border-radius: 8px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 1rem;
-        font-family: monospace;
+        font-family: var(--font-mono);
         font-size: 0.85rem;
         max-height: 300px;
         overflow-y: auto;
     }
-    
+
     .indicator-item {
         padding: 0.5rem;
         margin-bottom: 0.5rem;
-        background: white;
-        border-radius: 4px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        color: var(--text-soft);
         word-break: break-all;
     }
-    
+
     .code-block {
-        background: #1e293b;
-        color: #e2e8f0;
+        background: #05050a;
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
+        color: var(--text-soft);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         overflow-x: auto;
-        font-family: monospace;
+        font-family: var(--font-mono);
         font-size: 0.85rem;
         position: relative;
         margin-bottom: 1rem;
     }
-    
+
     .copy-btn {
         position: absolute;
         top: 0.5rem;
         right: 0.5rem;
-        background: rgba(255,255,255,0.1);
-        border: 1px solid rgba(255,255,255,0.2);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent);
         padding: 0.25rem 0.75rem;
-        border-radius: 4px;
+        border-radius: var(--border-radius);
+        font-family: var(--font-mono);
         font-size: 0.75rem;
         cursor: pointer;
-        transition: background 0.2s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .copy-btn:hover {
-        background: rgba(255,255,255,0.2);
+        background: var(--surface);
+        border-color: var(--accent);
     }
-    
+
     /* Analysis Section */
     .analysis-section {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+        box-shadow: var(--shadow);
     }
-    
+
     .analysis-content {
         line-height: 1.8;
-        color: var(--text-color);
+        color: var(--text-soft);
     }
-    
+
     .analysis-content h2 {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        color: #0e7490;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 2rem 0 1rem;
         padding-bottom: 0.5rem;
-        border-bottom: 2px solid #e0e7ff;
+        border-bottom: 1px solid var(--border);
     }
-    
+
     .analysis-content h3 {
         font-size: 1.25rem;
-        color: var(--text-color);
+        color: var(--text);
         margin: 1.5rem 0 1rem;
     }
-    
+
     .analysis-content pre {
-        background: #f9fafb;
-        border: 1px solid #e5e7eb;
-        border-radius: 8px;
+        background: #05050a;
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
+        border-radius: var(--border-radius);
         padding: 1rem;
         overflow-x: auto;
         margin: 1rem 0;
+        font-family: var(--font-mono);
+        color: var(--text-soft);
     }
-    
+
     .analysis-content code {
-        background: #f3f4f6;
+        background: var(--surface-3);
+        color: var(--accent3);
         padding: 0.125rem 0.25rem;
         border-radius: 3px;
+        font-family: var(--font-mono);
         font-size: 0.9em;
     }
-    
+
     .analysis-content table {
         width: 100%;
         border-collapse: collapse;
         margin: 1rem 0;
     }
-    
+
     .analysis-content th,
     .analysis-content td {
         padding: 0.75rem;
         text-align: left;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--border);
     }
-    
+
     .analysis-content th {
-        background: #f9fafb;
+        background: var(--surface-2);
+        color: var(--accent);
         font-weight: 600;
+        border-bottom: 2px solid var(--accent);
     }
-    
+
     .analysis-content tr:hover {
-        background: #f9fafb;
+        background: var(--highlight);
     }
     
     /* Responsive */
@@ -485,7 +520,7 @@
     .empty-state {
         text-align: center;
         padding: 3rem;
-        color: var(--text-light);
+        color: var(--muted);
     }
     
     .empty-icon {
@@ -535,7 +570,7 @@
 <!-- Download Section -->
 <div style="display: flex; gap: 1rem; margin-bottom: 2rem; flex-wrap: wrap;">
     <a href="https://github.com/MHaggis/ClickGrab/tree/main/nightly_reports" 
-       class="action-btn" style="text-decoration: none; background: #0e7490; color: white; padding: 0.75rem 1.5rem;" target="_blank">
+       class="action-btn" style="text-decoration: none; background: var(--accent); border-color: var(--accent); color: var(--bg); padding: 0.75rem 1.5rem;" target="_blank">
         ⬇️ Download JSON Report
     </a>
     <a href="https://github.com/MHaggis/ClickGrab/tree/main/nightly_reports" 
@@ -591,29 +626,29 @@
     </div>
     
     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin-bottom: 2rem;">
-        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-            <div style="font-size: 1.5rem; font-weight: 700; color: #dc2626;">17</div>
-            <div style="font-size: 0.9rem; color: var(--text-light);">High Risk Commands</div>
+        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent2);">17</div>
+            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">High Risk Commands</div>
         </div>
-        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-            <div style="font-size: 1.5rem; font-weight: 700; color: #f59e0b;">569</div>
-            <div style="font-size: 0.9rem; color: var(--text-light);">Base64 Encoded</div>
+        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent4);">569</div>
+            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">Base64 Encoded</div>
         </div>
-        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-            <div style="font-size: 1.5rem; font-weight: 700; color: #8b5cf6;">0</div>
-            <div style="font-size: 0.9rem; color: var(--text-light);">Obfuscated JS</div>
+        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent3);">0</div>
+            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">Obfuscated JS</div>
         </div>
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.5rem; font-weight: 700; color: #3b82f6;">47</div>
-                            <div style="font-size: 0.9rem; color: var(--text-light);">Inline JS Redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent3);">47</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">Inline JS Redirects</div>
                         </div>
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                        <div style="font-size: 1.5rem; font-weight: 700; color: #ec4899;">9</div>
-                            <div style="font-size: 0.9rem; color: var(--text-light);">External JS Chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                        <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent2);">9</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">External JS Chains</div>
                         </div>
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.5rem; font-weight: 700; color: #22c55e;">40</div>
-                            <div style="font-size: 0.9rem; color: var(--text-light);">Redirect Follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent);">40</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">Redirect Follows</div>
                         </div>
     </div>
 
@@ -676,35 +711,35 @@
         <h3 style="margin:0 0 .5rem 0;">Top Indicators/Keywords</h3>
         <div style="display:flex; gap:.5rem; flex-wrap:wrap;">
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">robot (8)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">robot (8)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">hidden (7)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">hidden (7)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Robot (6)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Robot (6)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">CAPTCHA Verification (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">CAPTCHA Verification (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Verification ID (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Verification ID (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Ray ID (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Ray ID (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">I am not a robot (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">I am not a robot (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">You will observe (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">You will observe (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">CAPTCHA (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">CAPTCHA (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">CAPTCHA-verificatie-ID (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">CAPTCHA-verificatie-ID (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Verification (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Verification (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">verification (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">verification (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">verification-id (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">verification-id (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Checking if you are human (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Checking if you are human (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Verify you are human (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Verify you are human (5)</span>
             
         </div>
     </div>
@@ -714,8 +749,8 @@
 <!-- Detailed Site Analysis -->
 <section class="sites-section">
     <div class="sites-header">
-        <h2 style="font-size: 1.75rem; font-weight: 600;">Malicious Sites Detected</h2>
-        <span style="color: var(--text-light);">Click on a site to view detailed analysis</span>
+        <h2 style="font-family: var(--font-display); font-size: 1.75rem; font-weight: 400; letter-spacing: 1px; color: var(--text);">Malicious Sites Detected</h2>
+        <span style="font-family: var(--font-mono); color: var(--muted);">Click on a site to view detailed analysis</span>
     </div>
     
     
@@ -725,7 +760,7 @@
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://picsera.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             2129 indicators detected
                         </div>
                     </div>
@@ -754,29 +789,29 @@
                 <div id="overview-1" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">9</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">9</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">8</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">8</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -834,7 +869,7 @@
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 1 of 1 entries (truncated for performance)
                         </p>
                         
@@ -922,7 +957,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://www.bharatnamkeens.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             1563 indicators detected
                         </div>
                     </div>
@@ -947,19 +982,19 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div id="overview-2" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">19</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">19</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1032,7 +1067,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://94.130.229.174/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             590 indicators detected
                         </div>
                     </div>
@@ -1059,29 +1094,29 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div id="overview-3" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect chains</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1143,7 +1178,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 1 of 1 chains (truncated for performance)
                         </p>
                         
@@ -1192,7 +1227,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://74.50.99.45:8443/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             2374 indicators detected
                         </div>
                     </div>
@@ -1221,29 +1256,29 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div id="overview-4" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">6</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">6</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">captcha</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">captcha</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">223</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">223</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">22</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">22</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">high risk</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">high risk</div>
                         </div>
                         
                     </div>
@@ -1313,7 +1348,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 6 entries (truncated for performance)
                         </p>
                         
@@ -1344,7 +1379,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://fudgeshop.com.au</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             686 indicators detected
                         </div>
                     </div>
@@ -1371,29 +1406,29 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div id="overview-5" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">18</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">18</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect chains</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1453,7 +1488,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 3 chains (truncated for performance)
                         </p>
                         
@@ -1588,7 +1623,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://44.208.147.17/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             543 indicators detected
                         </div>
                     </div>
@@ -1613,19 +1648,19 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div id="overview-6" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">7</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">7</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1694,7 +1729,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://capazmente.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             353 indicators detected
                         </div>
                     </div>
@@ -1721,24 +1756,24 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div id="overview-7" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">9</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">9</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">8</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">8</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1804,7 +1839,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 1 of 1 entries (truncated for performance)
                         </p>
                         
@@ -1830,7 +1865,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://98.70.13.131/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             801 indicators detected
                         </div>
                     </div>
@@ -1857,29 +1892,29 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div id="overview-8" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">35</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">35</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect chains</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">6</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">6</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1939,7 +1974,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 2 chains (truncated for performance)
                         </p>
                         
@@ -2105,7 +2140,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://creatorssky.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             388 indicators detected
                         </div>
                     </div>
@@ -2132,19 +2167,19 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div id="overview-9" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">7</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">7</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2208,7 +2243,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 1 of 1 entries (truncated for performance)
                         </p>
                         
@@ -2234,7 +2269,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://5.63.157.201/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             98 indicators detected
                         </div>
                     </div>
@@ -2261,24 +2296,24 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div id="overview-10" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2380,7 +2415,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://senevie.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             300 indicators detected
                         </div>
                     </div>
@@ -2405,19 +2440,19 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-11" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">39</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">39</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">6</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">6</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2492,7 +2527,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://www.scillarodriguez.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             281 indicators detected
                         </div>
                     </div>
@@ -2517,19 +2552,19 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-12" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2598,7 +2633,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://www.dorper.com.au</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             229 indicators detected
                         </div>
                     </div>
@@ -2625,29 +2660,29 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-13" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">26</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">26</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect chains</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2711,7 +2746,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 1 of 1 chains (truncated for performance)
                         </p>
                         
@@ -2772,7 +2807,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://evodigital.com.au</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             264 indicators detected
                         </div>
                     </div>
@@ -2799,24 +2834,24 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-14" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">37</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">37</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">7</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">7</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2937,7 +2972,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://www.maheshwaree.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             244 indicators detected
                         </div>
                     </div>
@@ -2962,14 +2997,14 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-15" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">23</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">23</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -3040,7 +3075,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://maheshwaree.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             244 indicators detected
                         </div>
                     </div>
@@ -3065,14 +3100,14 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-16" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">23</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">23</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -3143,7 +3178,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://revistadiversidadcultural.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             122 indicators detected
                         </div>
                     </div>
@@ -3170,29 +3205,29 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-17" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect chains</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -3252,7 +3287,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 2 chains (truncated for performance)
                         </p>
                         
@@ -3374,7 +3409,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://173.231.196.249/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             79 indicators detected
                         </div>
                     </div>
@@ -3403,34 +3438,34 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-18" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">powershell</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">powershell</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">6</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">6</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">captcha</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">captcha</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">27</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">27</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">high risk</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">high risk</div>
                         </div>
                         
                     </div>
@@ -3514,7 +3549,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 6 entries (truncated for performance)
                         </p>
                         
@@ -3545,7 +3580,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://103.74.5.124/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             74 indicators detected
                         </div>
                     </div>
@@ -3574,29 +3609,29 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-19" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">powershell</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">powershell</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">6</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">6</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">captcha</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">captcha</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">22</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">22</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -3678,7 +3713,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 6 entries (truncated for performance)
                         </p>
                         
@@ -3709,7 +3744,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">http://103.241.42.40/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             68 indicators detected
                         </div>
                     </div>
@@ -3738,24 +3773,24 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-20" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">6</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">6</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">captcha</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">captcha</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">19</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">19</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -3825,7 +3860,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 6 entries (truncated for performance)
                         </p>
                         
@@ -3853,7 +3888,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
         
         
         
-        <div style="text-align: center; padding: 2rem; color: var(--text-light);">
+        <div style="text-align: center; padding: 2rem; font-family: var(--font-mono); color: var(--muted);">
             <p>Showing top 20 malicious sites. 18 additional sites detected.</p>
         </div>
         

--- a/docs/reports/2026-05-31.html
+++ b/docs/reports/2026-05-31.html
@@ -5,28 +5,28 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ClickGrab Report - May 31, 2026</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <style>
     /* Report Header */
     .report-hero {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         position: relative;
         overflow: hidden;
+        box-shadow: var(--shadow);
     }
-    
+
     .report-hero::before {
         content: '';
         position: absolute;
@@ -34,27 +34,31 @@
         left: 0;
         right: 0;
         bottom: 0;
-        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><pattern id="grid" width="10" height="10" patternUnits="userSpaceOnUse"><path d="M 10 0 L 0 0 0 10" fill="none" stroke="rgba(255,255,255,0.1)" stroke-width="0.5"/></pattern><rect width="100" height="100" fill="url(%23grid)"/></svg>');
-        opacity: 0.3;
+        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><pattern id="grid" width="10" height="10" patternUnits="userSpaceOnUse"><path d="M 10 0 L 0 0 0 10" fill="none" stroke="rgba(0,255,136,0.06)" stroke-width="0.5"/></pattern><rect width="100" height="100" fill="url(%23grid)"/></svg>');
+        opacity: 0.5;
     }
-    
+
     .report-hero-content {
         position: relative;
         z-index: 1;
     }
-    
+
     .report-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 700;
+        font-weight: 400;
+        letter-spacing: 2px;
+        color: var(--accent);
         margin-bottom: 1rem;
     }
-    
+
     .report-meta {
         display: flex;
         gap: 2rem;
         flex-wrap: wrap;
-        font-size: 1.1rem;
-        opacity: 0.95;
+        font-family: var(--font-mono);
+        font-size: 0.95rem;
+        color: var(--text-soft);
     }
     
     /* Summary Cards */
@@ -66,78 +70,82 @@
     }
     
     .summary-card {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 1.5rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+        box-shadow: var(--shadow);
         text-align: center;
-        transition: transform 0.3s ease;
-        border: 1px solid #e5e7eb;
+        transition: transform 0.18s ease, border-color 0.18s ease;
+        border: 1px solid var(--border);
         position: relative;
         overflow: hidden;
     }
-    
+
     .summary-card::before {
         content: '';
         position: absolute;
         top: 0;
         left: 0;
         right: 0;
-        height: 4px;
-        background: linear-gradient(90deg, var(--gradient-start), var(--gradient-end));
+        height: 3px;
+        background: var(--accent-edge, var(--accent));
     }
-    
-    .summary-card.total { --gradient-start: #0e7490; --gradient-end: #0f766e; }
-    .summary-card.threats { --gradient-start: #22c55e; --gradient-end: #0891b2; }
-    .summary-card.powershell { --gradient-start: #4facfe; --gradient-end: #00f2fe; }
-    .summary-card.clipboard { --gradient-start: #fa709a; --gradient-end: #fee140; }
-    .summary-card.score { --gradient-start: #30cfd0; --gradient-end: #330867; }
-    
+
+    .summary-card.total { --accent-edge: var(--accent3); }
+    .summary-card.threats { --accent-edge: var(--accent2); }
+    .summary-card.powershell { --accent-edge: var(--accent3); }
+    .summary-card.clipboard { --accent-edge: var(--accent4); }
+    .summary-card.score { --accent-edge: var(--accent); }
+
     .summary-card:hover {
-        transform: translateY(-5px);
-        box-shadow: 0 8px 30px rgba(0,0,0,0.12);
+        transform: translateY(-2px);
+        border-color: var(--accent);
     }
-    
+
     .summary-icon {
         font-size: 2.5rem;
         margin-bottom: 1rem;
     }
-    
+
     .summary-value {
+        font-family: var(--font-mono);
         font-size: 2.5rem;
         font-weight: 700;
-        color: var(--text-color);
+        color: var(--text);
         margin-bottom: 0.5rem;
     }
-    
+
     .summary-label {
-        color: var(--text-light);
+        font-family: var(--font-mono);
+        color: var(--muted);
         font-size: 0.9rem;
         text-transform: uppercase;
         letter-spacing: 0.5px;
     }
-    
+
     .summary-change {
         margin-top: 0.5rem;
+        font-family: var(--font-mono);
         font-size: 0.85rem;
         display: flex;
         align-items: center;
         justify-content: center;
         gap: 0.25rem;
     }
-    
-    .change-up { color: #ef4444; }
-    .change-down { color: #22c55e; }
+
+    .change-up { color: var(--accent2); }
+    .change-down { color: var(--accent); }
     
     /* Threat Overview */
     .threat-overview {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
         margin-bottom: 3rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+        box-shadow: var(--shadow);
     }
-    
+
     .threat-header {
         display: flex;
         justify-content: space-between;
@@ -146,33 +154,36 @@
         flex-wrap: wrap;
         gap: 1rem;
     }
-    
+
     .threat-title {
+        font-family: var(--font-display);
         font-size: 1.75rem;
-        font-weight: 600;
-        color: var(--text-color);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
     }
-    
+
     .threat-actions {
         display: flex;
         gap: 1rem;
     }
-    
+
     .action-btn {
         padding: 0.5rem 1rem;
-        border: 1px solid #e5e7eb;
-        border-radius: 8px;
-        background: white;
-        color: var(--text-color);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        background: var(--surface-2);
+        color: var(--text-soft);
+        font-family: var(--font-mono);
         font-size: 0.9rem;
         cursor: pointer;
-        transition: all 0.2s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .action-btn:hover {
-        background: #f9fafb;
-        border-color: #0e7490;
-        color: #0e7490;
+        background: var(--surface-3);
+        border-color: var(--accent);
+        color: var(--accent);
     }
 
     /* Simple bar chart styles */
@@ -183,14 +194,14 @@
         margin-top: 1rem;
     }
     .bar {
-        background: #f9fafb;
-        border: 1px solid #e5e7eb;
-        border-radius: 8px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 0.75rem;
     }
-    .bar-label { font-size: 0.9rem; color: var(--text-light); }
-    .bar-track { height: 10px; background: #eef2ff; border-radius: 6px; margin-top: 0.5rem; overflow: hidden; }
-    .bar-fill { height: 100%; background: linear-gradient(90deg,#0e7490,#0f766e); border-radius: 6px; width: 0%; transition: width .6s ease; }
+    .bar-label { font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted); }
+    .bar-track { height: 10px; background: var(--surface-3); border-radius: 6px; margin-top: 0.5rem; overflow: hidden; }
+    .bar-fill { height: 100%; background: var(--accent); border-radius: 6px; width: 0%; transition: width .6s ease; }
     
     /* Site Analysis Cards */
     .sites-section {
@@ -205,27 +216,27 @@
     }
     
     .site-card {
-        background: white;
-        border-radius: 12px;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.08);
+        background: var(--surface);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
         margin-bottom: 1.5rem;
         overflow: hidden;
-        transition: all 0.3s ease;
-        border: 1px solid #e5e7eb;
+        transition: all 0.18s ease;
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
     }
-    
+
     .site-card:hover {
-        box-shadow: 0 4px 20px rgba(0,0,0,0.12);
-        border-color: #0e7490;
+        border-color: var(--accent);
     }
-    
+
     .site-header {
-        background: #f9fafb;
+        background: var(--surface-2);
         padding: 1.5rem;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--border);
         cursor: pointer;
     }
-    
+
     .site-header-content {
         display: flex;
         justify-content: space-between;
@@ -233,41 +244,44 @@
         flex-wrap: wrap;
         gap: 1rem;
     }
-    
+
     .site-url {
         font-weight: 600;
-        color: #ef4444;
+        color: var(--accent2);
         word-break: break-all;
-        font-family: monospace;
+        font-family: var(--font-mono);
         font-size: 0.95rem;
     }
-    
+
     .site-badges {
         display: flex;
         gap: 0.5rem;
         flex-wrap: wrap;
     }
-    
+
     .threat-score-badge {
         padding: 0.25rem 0.75rem;
         border-radius: 20px;
+        font-family: var(--font-mono);
         font-size: 0.8rem;
         font-weight: 600;
-        color: white;
+        color: var(--bg);
     }
-    
-    .score-critical { background: #dc2626; }
-    .score-high { background: #ef4444; }
-    .score-medium { background: #f59e0b; }
-    .score-low { background: #3b82f6; }
-    
+
+    .score-critical { background: var(--accent2); }
+    .score-high { background: var(--accent2); }
+    .score-medium { background: var(--accent4); }
+    .score-low { background: var(--accent); }
+
     .attack-type-badge {
         padding: 0.25rem 0.75rem;
         border-radius: 20px;
+        font-family: var(--font-mono);
         font-size: 0.8rem;
         font-weight: 500;
-        background: #e0e7ff;
-        color: #4c1d95;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent3);
     }
     
     .site-details {
@@ -283,28 +297,29 @@
         display: flex;
         gap: 1rem;
         margin-bottom: 1.5rem;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--border);
     }
-    
+
     .detail-tab {
         padding: 0.5rem 1rem;
         border: none;
         background: none;
-        color: var(--text-light);
+        color: var(--muted);
+        font-family: var(--font-mono);
         font-weight: 500;
         cursor: pointer;
         position: relative;
-        transition: color 0.2s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .detail-tab:hover {
-        color: var(--text-color);
+        color: var(--text);
     }
-    
+
     .detail-tab.active {
-        color: #0e7490;
+        color: var(--accent);
     }
-    
+
     .detail-tab.active::after {
         content: '';
         position: absolute;
@@ -312,7 +327,7 @@
         left: 0;
         right: 0;
         height: 2px;
-        background: #0e7490;
+        background: var(--accent);
     }
     
     .tab-content {
@@ -332,132 +347,152 @@
         font-size: 1.1rem;
         font-weight: 600;
         margin-bottom: 1rem;
-        color: var(--text-color);
+        color: var(--text);
         display: flex;
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .indicator-count {
-        background: #e0e7ff;
-        color: #4c1d95;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent3);
         padding: 0.125rem 0.5rem;
         border-radius: 12px;
+        font-family: var(--font-mono);
         font-size: 0.8rem;
         font-weight: 500;
     }
-    
+
     .indicator-list {
-        background: #f9fafb;
-        border-radius: 8px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 1rem;
-        font-family: monospace;
+        font-family: var(--font-mono);
         font-size: 0.85rem;
         max-height: 300px;
         overflow-y: auto;
     }
-    
+
     .indicator-item {
         padding: 0.5rem;
         margin-bottom: 0.5rem;
-        background: white;
-        border-radius: 4px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        color: var(--text-soft);
         word-break: break-all;
     }
-    
+
     .code-block {
-        background: #1e293b;
-        color: #e2e8f0;
+        background: #05050a;
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
+        color: var(--text-soft);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         overflow-x: auto;
-        font-family: monospace;
+        font-family: var(--font-mono);
         font-size: 0.85rem;
         position: relative;
         margin-bottom: 1rem;
     }
-    
+
     .copy-btn {
         position: absolute;
         top: 0.5rem;
         right: 0.5rem;
-        background: rgba(255,255,255,0.1);
-        border: 1px solid rgba(255,255,255,0.2);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent);
         padding: 0.25rem 0.75rem;
-        border-radius: 4px;
+        border-radius: var(--border-radius);
+        font-family: var(--font-mono);
         font-size: 0.75rem;
         cursor: pointer;
-        transition: background 0.2s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .copy-btn:hover {
-        background: rgba(255,255,255,0.2);
+        background: var(--surface);
+        border-color: var(--accent);
     }
-    
+
     /* Analysis Section */
     .analysis-section {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+        box-shadow: var(--shadow);
     }
-    
+
     .analysis-content {
         line-height: 1.8;
-        color: var(--text-color);
+        color: var(--text-soft);
     }
-    
+
     .analysis-content h2 {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        color: #0e7490;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 2rem 0 1rem;
         padding-bottom: 0.5rem;
-        border-bottom: 2px solid #e0e7ff;
+        border-bottom: 1px solid var(--border);
     }
-    
+
     .analysis-content h3 {
         font-size: 1.25rem;
-        color: var(--text-color);
+        color: var(--text);
         margin: 1.5rem 0 1rem;
     }
-    
+
     .analysis-content pre {
-        background: #f9fafb;
-        border: 1px solid #e5e7eb;
-        border-radius: 8px;
+        background: #05050a;
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
+        border-radius: var(--border-radius);
         padding: 1rem;
         overflow-x: auto;
         margin: 1rem 0;
+        font-family: var(--font-mono);
+        color: var(--text-soft);
     }
-    
+
     .analysis-content code {
-        background: #f3f4f6;
+        background: var(--surface-3);
+        color: var(--accent3);
         padding: 0.125rem 0.25rem;
         border-radius: 3px;
+        font-family: var(--font-mono);
         font-size: 0.9em;
     }
-    
+
     .analysis-content table {
         width: 100%;
         border-collapse: collapse;
         margin: 1rem 0;
     }
-    
+
     .analysis-content th,
     .analysis-content td {
         padding: 0.75rem;
         text-align: left;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--border);
     }
-    
+
     .analysis-content th {
-        background: #f9fafb;
+        background: var(--surface-2);
+        color: var(--accent);
         font-weight: 600;
+        border-bottom: 2px solid var(--accent);
     }
-    
+
     .analysis-content tr:hover {
-        background: #f9fafb;
+        background: var(--highlight);
     }
     
     /* Responsive */
@@ -485,7 +520,7 @@
     .empty-state {
         text-align: center;
         padding: 3rem;
-        color: var(--text-light);
+        color: var(--muted);
     }
     
     .empty-icon {
@@ -535,7 +570,7 @@
 <!-- Download Section -->
 <div style="display: flex; gap: 1rem; margin-bottom: 2rem; flex-wrap: wrap;">
     <a href="https://github.com/MHaggis/ClickGrab/tree/main/nightly_reports" 
-       class="action-btn" style="text-decoration: none; background: #0e7490; color: white; padding: 0.75rem 1.5rem;" target="_blank">
+       class="action-btn" style="text-decoration: none; background: var(--accent); border-color: var(--accent); color: var(--bg); padding: 0.75rem 1.5rem;" target="_blank">
         ⬇️ Download JSON Report
     </a>
     <a href="https://github.com/MHaggis/ClickGrab/tree/main/nightly_reports" 
@@ -591,29 +626,29 @@
     </div>
     
     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin-bottom: 2rem;">
-        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-            <div style="font-size: 1.5rem; font-weight: 700; color: #dc2626;">17</div>
-            <div style="font-size: 0.9rem; color: var(--text-light);">High Risk Commands</div>
+        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent2);">17</div>
+            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">High Risk Commands</div>
         </div>
-        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-            <div style="font-size: 1.5rem; font-weight: 700; color: #f59e0b;">598</div>
-            <div style="font-size: 0.9rem; color: var(--text-light);">Base64 Encoded</div>
+        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent4);">598</div>
+            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">Base64 Encoded</div>
         </div>
-        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-            <div style="font-size: 1.5rem; font-weight: 700; color: #8b5cf6;">0</div>
-            <div style="font-size: 0.9rem; color: var(--text-light);">Obfuscated JS</div>
+        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent3);">0</div>
+            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">Obfuscated JS</div>
         </div>
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.5rem; font-weight: 700; color: #3b82f6;">46</div>
-                            <div style="font-size: 0.9rem; color: var(--text-light);">Inline JS Redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent3);">46</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">Inline JS Redirects</div>
                         </div>
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                        <div style="font-size: 1.5rem; font-weight: 700; color: #ec4899;">10</div>
-                            <div style="font-size: 0.9rem; color: var(--text-light);">External JS Chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                        <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent2);">10</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">External JS Chains</div>
                         </div>
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.5rem; font-weight: 700; color: #22c55e;">38</div>
-                            <div style="font-size: 0.9rem; color: var(--text-light);">Redirect Follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent);">38</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">Redirect Follows</div>
                         </div>
     </div>
 
@@ -676,35 +711,35 @@
         <h3 style="margin:0 0 .5rem 0;">Top Indicators/Keywords</h3>
         <div style="display:flex; gap:.5rem; flex-wrap:wrap;">
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">robot (9)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">robot (9)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">hidden (8)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">hidden (8)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Robot (6)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Robot (6)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">CAPTCHA Verification (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">CAPTCHA Verification (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Verification ID (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Verification ID (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Ray ID (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Ray ID (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">I am not a robot (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">I am not a robot (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">You will observe (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">You will observe (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">CAPTCHA (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">CAPTCHA (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">CAPTCHA-verificatie-ID (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">CAPTCHA-verificatie-ID (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Verification (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Verification (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">verification (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">verification (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">verification-id (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">verification-id (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Checking if you are human (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Checking if you are human (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Verify you are human (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Verify you are human (4)</span>
             
         </div>
     </div>
@@ -714,8 +749,8 @@
 <!-- Detailed Site Analysis -->
 <section class="sites-section">
     <div class="sites-header">
-        <h2 style="font-size: 1.75rem; font-weight: 600;">Malicious Sites Detected</h2>
-        <span style="color: var(--text-light);">Click on a site to view detailed analysis</span>
+        <h2 style="font-family: var(--font-display); font-size: 1.75rem; font-weight: 400; letter-spacing: 1px; color: var(--text);">Malicious Sites Detected</h2>
+        <span style="font-family: var(--font-mono); color: var(--muted);">Click on a site to view detailed analysis</span>
     </div>
     
     
@@ -725,7 +760,7 @@
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://picsera.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             2128 indicators detected
                         </div>
                     </div>
@@ -754,29 +789,29 @@
                 <div id="overview-1" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">9</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">9</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">8</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">8</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -834,7 +869,7 @@
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 1 of 1 entries (truncated for performance)
                         </p>
                         
@@ -922,7 +957,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://www.bharatnamkeens.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             1566 indicators detected
                         </div>
                     </div>
@@ -947,19 +982,19 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div id="overview-2" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">19</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">19</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1032,7 +1067,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">http://192.155.93.247:3101/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             1025 indicators detected
                         </div>
                     </div>
@@ -1057,14 +1092,14 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div id="overview-3" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">6</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">6</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1133,7 +1168,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://104.199.248.167/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             705 indicators detected
                         </div>
                     </div>
@@ -1158,14 +1193,14 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div id="overview-4" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1234,7 +1269,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://74.50.99.45:8443/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             2618 indicators detected
                         </div>
                     </div>
@@ -1263,29 +1298,29 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div id="overview-5" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">6</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">6</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">captcha</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">captcha</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">244</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">244</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">22</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">22</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">high risk</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">high risk</div>
                         </div>
                         
                     </div>
@@ -1355,7 +1390,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 6 entries (truncated for performance)
                         </p>
                         
@@ -1386,7 +1421,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://94.130.229.174/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             590 indicators detected
                         </div>
                     </div>
@@ -1413,29 +1448,29 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div id="overview-6" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect chains</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1497,7 +1532,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 1 of 1 chains (truncated for performance)
                         </p>
                         
@@ -1546,7 +1581,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://fudgeshop.com.au</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             686 indicators detected
                         </div>
                     </div>
@@ -1573,29 +1608,29 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div id="overview-7" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">18</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">18</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect chains</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1655,7 +1690,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 3 chains (truncated for performance)
                         </p>
                         
@@ -1790,7 +1825,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://44.208.147.17/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             543 indicators detected
                         </div>
                     </div>
@@ -1815,19 +1850,19 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div id="overview-8" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">7</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">7</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1896,7 +1931,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://capazmente.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             353 indicators detected
                         </div>
                     </div>
@@ -1923,24 +1958,24 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div id="overview-9" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">9</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">9</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">8</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">8</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2006,7 +2041,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 1 of 1 entries (truncated for performance)
                         </p>
                         
@@ -2032,7 +2067,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://98.70.13.131/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             799 indicators detected
                         </div>
                     </div>
@@ -2059,29 +2094,29 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div id="overview-10" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">35</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">35</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect chains</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">6</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">6</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2141,7 +2176,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 2 chains (truncated for performance)
                         </p>
                         
@@ -2307,7 +2342,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://creatorssky.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             388 indicators detected
                         </div>
                     </div>
@@ -2334,19 +2369,19 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div id="overview-11" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">7</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">7</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2410,7 +2445,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 1 of 1 entries (truncated for performance)
                         </p>
                         
@@ -2436,7 +2471,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://5.63.157.201/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             95 indicators detected
                         </div>
                     </div>
@@ -2463,24 +2498,24 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div id="overview-12" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2582,7 +2617,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://senevie.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             300 indicators detected
                         </div>
                     </div>
@@ -2607,19 +2642,19 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-13" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">39</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">39</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">6</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">6</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2694,7 +2729,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://www.scillarodriguez.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             282 indicators detected
                         </div>
                     </div>
@@ -2719,19 +2754,19 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-14" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2800,7 +2835,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://www.dorper.com.au</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             229 indicators detected
                         </div>
                     </div>
@@ -2827,29 +2862,29 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-15" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">26</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">26</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect chains</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2913,7 +2948,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 1 of 1 chains (truncated for performance)
                         </p>
                         
@@ -2974,7 +3009,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://evodigital.com.au</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             264 indicators detected
                         </div>
                     </div>
@@ -3001,24 +3036,24 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-16" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">37</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">37</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">7</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">7</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -3139,7 +3174,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://www.maheshwaree.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             244 indicators detected
                         </div>
                     </div>
@@ -3164,14 +3199,14 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-17" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">23</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">23</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -3242,7 +3277,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://maheshwaree.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             244 indicators detected
                         </div>
                     </div>
@@ -3267,14 +3302,14 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-18" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">23</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">23</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -3345,7 +3380,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">http://172.96.189.153/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             265 indicators detected
                         </div>
                     </div>
@@ -3374,29 +3409,29 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-19" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">captcha</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">captcha</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">14</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">14</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -3516,7 +3551,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://revistadiversidadcultural.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             122 indicators detected
                         </div>
                     </div>
@@ -3543,29 +3578,29 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-20" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect chains</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -3625,7 +3660,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 2 chains (truncated for performance)
                         </p>
                         
@@ -3744,7 +3779,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
         
         
         
-        <div style="text-align: center; padding: 2rem; color: var(--text-light);">
+        <div style="text-align: center; padding: 2rem; font-family: var(--font-mono); color: var(--muted);">
             <p>Showing top 20 malicious sites. 22 additional sites detected.</p>
         </div>
         

--- a/docs/techniques.html
+++ b/docs/techniques.html
@@ -5,226 +5,251 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ClickFix Techniques - ClickGrab</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     /* ClickFix Wiki Styling */
     .techniques-header {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: linear-gradient(135deg, var(--surface-2) 0%, var(--surface-3) 100%);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        box-shadow: var(--shadow);
         margin-bottom: 3rem;
         text-align: center;
     }
-    
+
     .techniques-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        color: white;
+        color: var(--accent);
     }
-    
+
     .techniques-subtitle {
         font-size: 1.2rem;
-        color: white;
+        color: var(--text-soft);
         max-width: 600px;
         margin: 0 auto;
         line-height: 1.6;
     }
-    /* Enforce white for any nested text in header/subtitle against global styles */
-    .techniques-header,
-    .techniques-header *,
-    .techniques-title,
-    .techniques-subtitle {
-        color: #FFFFFF !important;
+    /* Keep header copy readable against the dark surface */
+    .techniques-header .techniques-subtitle,
+    .techniques-header .techniques-subtitle * {
+        color: var(--text-soft) !important;
     }
-    
+    .techniques-header .techniques-title {
+        color: var(--accent) !important;
+    }
+
     .search-section {
         margin-bottom: 2rem;
     }
-    
+
     .search-box {
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
-    
+
     .filter-section {
         margin-bottom: 3rem;
     }
-    
+
     .filter-groups {
         display: flex;
         gap: 2rem;
         flex-wrap: wrap;
         justify-content: center;
     }
-    
+
     .filter-group {
-        background: white;
+        background: var(--surface);
         padding: 1.5rem;
-        border-radius: 12px;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
         min-width: 200px;
     }
-    
+
     .filter-group-title {
+        font-family: var(--font-mono);
         font-weight: 600;
         margin-bottom: 1rem;
-        color: #333;
+        color: var(--accent);
         font-size: 0.9rem;
         text-transform: uppercase;
         letter-spacing: 1px;
     }
-    
+
     .filter-tags {
         display: flex;
         flex-direction: column;
         gap: 0.5rem;
     }
-    
+
     .filter-tag {
         padding: 0.5rem 1rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 25px;
+        background: var(--surface-2);
+        color: var(--text-soft);
         cursor: pointer;
-        transition: all 0.3s ease;
+        transition: all 0.18s ease;
         font-size: 0.9rem;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .filter-tag:hover {
-        border-color: #0e7490;
-        background: rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        background: var(--highlight);
+        color: var(--text);
     }
-    
+
     .filter-tag.active {
-        background: #0e7490;
-        color: white;
-        border-color: #0e7490;
+        background: var(--accent);
+        color: var(--bg);
+        border-color: var(--accent);
     }
-    
+
     .tools-list {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
         gap: 1.5rem;
         margin-bottom: 3rem;
     }
-    
+
     .tool-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 1.5rem;
         text-decoration: none;
-        color: inherit;
-        transition: all 0.3s ease;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border: 1px solid transparent;
+        color: var(--text);
+        transition: all 0.18s ease;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
         position: relative;
         overflow: hidden;
     }
-    
+
     .tool-item::before {
         content: '';
         position: absolute;
         top: 0;
         left: 0;
         right: 0;
-        height: 4px;
-        background: linear-gradient(90deg, #0e7490, #0f766e);
+        height: 3px;
+        background: var(--accent);
         transform: scaleX(0);
-        transition: transform 0.3s ease;
+        transition: transform 0.18s ease;
     }
-    
+
     .tool-item:hover {
-        transform: translateY(-5px);
-        box-shadow: 0 8px 30px rgba(0,0,0,0.12);
-        border-color: #0e7490;
+        transform: translateY(-2px);
+        box-shadow: var(--shadow);
+        border-color: var(--accent);
     }
-    
+
     .tool-item:hover::before {
         transform: scaleX(1);
     }
-    
+
     .tool-title {
-        font-size: 1.25rem;
-        font-weight: 700;
+        font-family: var(--font-display);
+        font-size: 1.4rem;
+        font-weight: 400;
+        letter-spacing: 1px;
         margin-bottom: 1rem;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .tool-tags {
         display: flex;
         flex-wrap: wrap;
         gap: 0.5rem;
         margin-bottom: 1rem;
     }
-    
+
     .tool-tag {
         padding: 0.25rem 0.75rem;
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
     }
-    
+
     .tool-tag.platform-tag {
-        background: rgba(102, 126, 234, 0.1);
-        color: #0e7490;
+        background: rgba(61, 158, 255, 0.12);
+        color: var(--accent3);
+        border: 1px solid rgba(61, 158, 255, 0.25);
     }
-    
+
     .tool-tag.presentation-tag {
-        background: rgba(118, 75, 162, 0.1);
-        color: #0f766e;
+        background: var(--highlight);
+        color: var(--accent);
+        border: 1px solid rgba(0, 255, 136, 0.25);
     }
-    
+
     .tool-tag.capability-tag {
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: rgba(255, 204, 0, 0.12);
+        color: var(--accent4);
+        border: 1px solid rgba(255, 204, 0, 0.25);
     }
-    
+
     .tool-lure-count {
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         font-weight: 500;
     }
-    
+
     .no-results {
         text-align: center;
         padding: 3rem;
-        color: #666;
+        color: var(--muted);
     }
-    
+
     .no-results h3 {
+        font-family: var(--font-display);
         font-size: 1.5rem;
+        font-weight: 400;
+        letter-spacing: 1px;
         margin-bottom: 0.5rem;
-        color: #333;
+        color: var(--text);
     }
     
     
@@ -298,7 +323,7 @@
                     <i class="fab fa-windows" style="color: #0078d4;"></i> Windows
                 </div>
                 <div class="filter-tag" data-platform="Mac" onclick="toggleFilter('platform', 'Mac', this)">
-                    <i class="fab fa-apple" style="color: #000000;"></i> Mac
+                    <i class="fab fa-apple" style="color: var(--text);"></i> Mac
                 </div>
                 <div class="filter-tag" data-platform="Linux" onclick="toggleFilter('platform', 'Linux', this)">
                     <i class="fab fa-linux" style="color: #f47421;"></i> Linux
@@ -322,7 +347,7 @@
             <div class="filter-group-title">Capabilities</div>
             <div class="filter-tags" id="capabilityTags">
                 <div class="filter-tag" data-capability="UAC" onclick="toggleFilter('capability', 'UAC', this)">
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 </div>
                 <div class="filter-tag" data-capability="MOTW" onclick="toggleFilter('capability', 'MOTW', this)">
                     <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
@@ -337,6 +362,360 @@
 
 <!-- Tools Grid -->
 <div class="tools-list" id="toolsGrid">
+    
+    <a href="/ClickGrab/techniques/explorer-shell-uris.html" class="tool-item" data-id="explorer-shell-uris">
+        <div class="tool-title">explorer shell URIs</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">2 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/office-uri.html" class="tool-item" data-id="office-uri">
+        <div class="tool-title">Office URI schemes (ms-word/ms-excel)</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/msra.exe.html" class="tool-item" data-id="msra.exe">
+        <div class="tool-title">msra.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="MOTW">
+                
+                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/consentfix.html" class="tool-item" data-id="consentfix">
+        <div class="tool-title">ConsentFix</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="BROWSER">
+                
+                browser
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/colorcpl.exe.html" class="tool-item" data-id="colorcpl.exe">
+        <div class="tool-title">colorcpl.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="MOTW">
+                
+                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                
+            </span>
+            
+            <div class="tool-lure-count">2 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/dcomcnfg.exe.html" class="tool-item" data-id="dcomcnfg.exe">
+        <div class="tool-title">dcomcnfg.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/search-ms.html" class="tool-item" data-id="search-ms">
+        <div class="tool-title">search-ms protocol</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/taskmgr.exe.html" class="tool-item" data-id="taskmgr.exe">
+        <div class="tool-title">taskmgr.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/msiexec.exe.html" class="tool-item" data-id="msiexec.exe">
+        <div class="tool-title">msiexec.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="CLI">
+                
+                CLI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/powershell.exe.html" class="tool-item" data-id="powershell.exe">
+        <div class="tool-title">powershell.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="MOTW">
+                
+                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="UAC">
+                
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
+                
+            </span>
+            
+            <div class="tool-lure-count">2 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/wextract.exe.html" class="tool-item" data-id="wextract.exe">
+        <div class="tool-title">wextract.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="CLI">
+                
+                CLI
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">2 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/eventvwr.exe.html" class="tool-item" data-id="eventvwr.exe">
+        <div class="tool-title">eventvwr.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">2 lures</div>
+        </div>
+    </a>
     
     <a href="/ClickGrab/techniques/conhost.exe.html" class="tool-item" data-id="conhost.exe">
         <div class="tool-title">conhost.exe</div>
@@ -354,11 +733,107 @@
             
             <span class="tool-tag capability-tag" data-capability="UAC">
                 
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 
             </span>
             
             <div class="tool-lure-count">2 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/filefix.html" class="tool-item" data-id="filefix">
+        <div class="tool-title">FileFix (Explorer address bar)</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="CLI">
+                
+                CLI
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">3 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/certutil.exe.html" class="tool-item" data-id="certutil.exe">
+        <div class="tool-title">certutil.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="MOTW">
+                
+                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="UAC">
+                
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
+                
+            </span>
+            
+            <div class="tool-lure-count">2 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/crashfix.html" class="tool-item" data-id="crashfix">
+        <div class="tool-title">CrashFix</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="BROWSER">
+                
+                browser
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="CLI">
+                
+                CLI
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
         </div>
     </a>
     
@@ -422,252 +897,6 @@
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/osascript.html" class="tool-item" data-id="osascript">
-        <div class="tool-title">osascript</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Mac">
-                
-                mac
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="CLI">
-                
-                CLI
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="Credential Theft">
-                
-                Credential Theft
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="Data Exfiltration">
-                
-                Data Exfiltration
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/explorer-shell-uris.html" class="tool-item" data-id="explorer-shell-uris">
-        <div class="tool-title">explorer shell URIs</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">2 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/search-ms.html" class="tool-item" data-id="search-ms">
-        <div class="tool-title">search-ms protocol</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/office-uri.html" class="tool-item" data-id="office-uri">
-        <div class="tool-title">Office URI schemes (ms-word/ms-excel)</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/regasm.exe.html" class="tool-item" data-id="regasm.exe">
-        <div class="tool-title">regasm.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="MOTW">
-                
-                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="UAC">
-                
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
-                
-            </span>
-            
-            <div class="tool-lure-count">2 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/filefix.html" class="tool-item" data-id="filefix">
-        <div class="tool-title">FileFix (Explorer address bar)</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="CLI">
-                
-                CLI
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">3 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/finger.exe.html" class="tool-item" data-id="finger.exe">
-        <div class="tool-title">finger.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="CLI">
-                
-                CLI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/forfiles.exe.html" class="tool-item" data-id="forfiles.exe">
-        <div class="tool-title">forfiles.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="CLI">
-                
-                CLI
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <div class="tool-lure-count">4 lures</div>
-        </div>
-    </a>
-    
     <a href="/ClickGrab/techniques/ftp.exe.html" class="tool-item" data-id="ftp.exe">
         <div class="tool-title">ftp.exe</div>
         <div class="tool-tags">
@@ -684,65 +913,11 @@
             
             <span class="tool-tag capability-tag" data-capability="UAC">
                 
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 
             </span>
             
             <div class="tool-lure-count">2 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/net-use-webdav.html" class="tool-item" data-id="net-use-webdav">
-        <div class="tool-title">net use (WebDAV)</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="CLI">
-                
-                CLI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/crashfix.html" class="tool-item" data-id="crashfix">
-        <div class="tool-title">CrashFix</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="BROWSER">
-                
-                browser
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="CLI">
-                
-                CLI
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
         </div>
     </a>
     
@@ -763,384 +938,6 @@
             <span class="tool-tag capability-tag" data-capability="GUI">
                 
                 GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/certutil.exe.html" class="tool-item" data-id="certutil.exe">
-        <div class="tool-title">certutil.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="MOTW">
-                
-                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="UAC">
-                
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
-                
-            </span>
-            
-            <div class="tool-lure-count">2 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/credwiz.exe.html" class="tool-item" data-id="credwiz.exe">
-        <div class="tool-title">credwiz.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="MOTW">
-                
-                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="UAC">
-                
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
-                
-            </span>
-            
-            <div class="tool-lure-count">2 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/wextract.exe.html" class="tool-item" data-id="wextract.exe">
-        <div class="tool-title">wextract.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="CLI">
-                
-                CLI
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">2 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/certreq.exe.html" class="tool-item" data-id="certreq.exe">
-        <div class="tool-title">certreq.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="MOTW">
-                
-                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="UAC">
-                
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
-                
-            </span>
-            
-            <div class="tool-lure-count">2 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/perfmon.exe.html" class="tool-item" data-id="perfmon.exe">
-        <div class="tool-title">perfmon.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/control.exe.html" class="tool-item" data-id="control.exe">
-        <div class="tool-title">control.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="MOTW">
-                
-                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="UAC">
-                
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
-                
-            </span>
-            
-            <div class="tool-lure-count">3 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/CompMgmtLauncher.exe.html" class="tool-item" data-id="CompMgmtLauncher.exe">
-        <div class="tool-title">CompMgmtLauncher.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">4 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/ssh.exe.html" class="tool-item" data-id="ssh.exe">
-        <div class="tool-title">ssh.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="CLI">
-                
-                CLI
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="UAC">
-                
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/consentfix.html" class="tool-item" data-id="consentfix">
-        <div class="tool-title">ConsentFix</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="BROWSER">
-                
-                browser
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/fsquirt.exe.html" class="tool-item" data-id="fsquirt.exe">
-        <div class="tool-title">fsquirt.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/taskmgr.exe.html" class="tool-item" data-id="taskmgr.exe">
-        <div class="tool-title">taskmgr.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/wt.exe.html" class="tool-item" data-id="wt.exe">
-        <div class="tool-title">wt.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="CLI">
-                
-                CLI
                 
             </span>
             
@@ -1190,8 +987,32 @@
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/eventvwr.exe.html" class="tool-item" data-id="eventvwr.exe">
-        <div class="tool-title">eventvwr.exe</div>
+    <a href="/ClickGrab/techniques/finger.exe.html" class="tool-item" data-id="finger.exe">
+        <div class="tool-title">finger.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="CLI">
+                
+                CLI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/control.exe.html" class="tool-item" data-id="control.exe">
+        <div class="tool-title">control.exe</div>
         <div class="tool-tags">
             <span class="tool-tag platform-tag" data-platform="Windows">
                 
@@ -1216,24 +1037,6 @@
                 
             </span>
             
-            <div class="tool-lure-count">2 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/mshta.exe.html" class="tool-item" data-id="mshta.exe">
-        <div class="tool-title">mshta.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
             <span class="tool-tag capability-tag" data-capability="MOTW">
                 
                 <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
@@ -1242,16 +1045,16 @@
             
             <span class="tool-tag capability-tag" data-capability="UAC">
                 
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 
             </span>
             
-            <div class="tool-lure-count">2 lures</div>
+            <div class="tool-lure-count">3 lures</div>
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/MRT.exe.html" class="tool-item" data-id="MRT.exe">
-        <div class="tool-title">MRT.exe</div>
+    <a href="/ClickGrab/techniques/credwiz.exe.html" class="tool-item" data-id="credwiz.exe">
+        <div class="tool-title">credwiz.exe</div>
         <div class="tool-tags">
             <span class="tool-tag platform-tag" data-platform="Windows">
                 
@@ -1278,7 +1081,7 @@
             
             <span class="tool-tag capability-tag" data-capability="UAC">
                 
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 
             </span>
             
@@ -1286,8 +1089,38 @@
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/powershell.exe.html" class="tool-item" data-id="powershell.exe">
-        <div class="tool-title">powershell.exe</div>
+    <a href="/ClickGrab/techniques/forfiles.exe.html" class="tool-item" data-id="forfiles.exe">
+        <div class="tool-title">forfiles.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="CLI">
+                
+                CLI
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <div class="tool-lure-count">4 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/regasm.exe.html" class="tool-item" data-id="regasm.exe">
+        <div class="tool-title">regasm.exe</div>
         <div class="tool-tags">
             <span class="tool-tag platform-tag" data-platform="Windows">
                 
@@ -1308,7 +1141,7 @@
             
             <span class="tool-tag capability-tag" data-capability="UAC">
                 
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 
             </span>
             
@@ -1316,8 +1149,8 @@
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/cmd.exe.html" class="tool-item" data-id="cmd.exe">
-        <div class="tool-title">cmd.exe</div>
+    <a href="/ClickGrab/techniques/wt.exe.html" class="tool-item" data-id="wt.exe">
+        <div class="tool-title">wt.exe</div>
         <div class="tool-tags">
             <span class="tool-tag platform-tag" data-platform="Windows">
                 
@@ -1330,13 +1163,43 @@
                 
             </span>
             
-            <span class="tool-tag capability-tag" data-capability="UAC">
+            <span class="tool-tag capability-tag" data-capability="CLI">
                 
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                CLI
                 
             </span>
             
-            <div class="tool-lure-count">2 lures</div>
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/fsquirt.exe.html" class="tool-item" data-id="fsquirt.exe">
+        <div class="tool-title">fsquirt.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
         </div>
     </a>
     
@@ -1370,74 +1233,8 @@
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/DxDiag.exe.html" class="tool-item" data-id="DxDiag.exe">
-        <div class="tool-title">DxDiag.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="MOTW">
-                
-                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/FileHistory.exe.html" class="tool-item" data-id="FileHistory.exe">
-        <div class="tool-title">FileHistory.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="MOTW">
-                
-                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="UAC">
-                
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
-                
-            </span>
-            
-            <div class="tool-lure-count">2 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/msbuild.exe.html" class="tool-item" data-id="msbuild.exe">
-        <div class="tool-title">msbuild.exe</div>
+    <a href="/ClickGrab/techniques/rundll32.exe.html" class="tool-item" data-id="rundll32.exe">
+        <div class="tool-title">rundll32.exe</div>
         <div class="tool-tags">
             <span class="tool-tag platform-tag" data-platform="Windows">
                 
@@ -1458,7 +1255,43 @@
             
             <span class="tool-tag capability-tag" data-capability="UAC">
                 
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
+                
+            </span>
+            
+            <div class="tool-lure-count">2 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/certreq.exe.html" class="tool-item" data-id="certreq.exe">
+        <div class="tool-title">certreq.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="MOTW">
+                
+                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="UAC">
+                
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 
             </span>
             
@@ -1490,32 +1323,8 @@
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/msiexec.exe.html" class="tool-item" data-id="msiexec.exe">
-        <div class="tool-title">msiexec.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="CLI">
-                
-                CLI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/dcomcnfg.exe.html" class="tool-item" data-id="dcomcnfg.exe">
-        <div class="tool-title">dcomcnfg.exe</div>
+    <a href="/ClickGrab/techniques/CompMgmtLauncher.exe.html" class="tool-item" data-id="CompMgmtLauncher.exe">
+        <div class="tool-title">CompMgmtLauncher.exe</div>
         <div class="tool-tags">
             <span class="tool-tag platform-tag" data-platform="Windows">
                 
@@ -1537,6 +1346,72 @@
             <span class="tool-tag capability-tag" data-capability="GUI">
                 
                 GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">4 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/FileHistory.exe.html" class="tool-item" data-id="FileHistory.exe">
+        <div class="tool-title">FileHistory.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="MOTW">
+                
+                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="UAC">
+                
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
+                
+            </span>
+            
+            <div class="tool-lure-count">2 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/ssh.exe.html" class="tool-item" data-id="ssh.exe">
+        <div class="tool-title">ssh.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="CLI">
+                
+                CLI
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="UAC">
+                
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 
             </span>
             
@@ -1586,8 +1461,68 @@
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/rundll32.exe.html" class="tool-item" data-id="rundll32.exe">
-        <div class="tool-title">rundll32.exe</div>
+    <a href="/ClickGrab/techniques/net-use-webdav.html" class="tool-item" data-id="net-use-webdav">
+        <div class="tool-title">net use (WebDAV)</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="CLI">
+                
+                CLI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/osascript.html" class="tool-item" data-id="osascript">
+        <div class="tool-title">osascript</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Mac">
+                
+                mac
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="CLI">
+                
+                CLI
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="Credential Theft">
+                
+                Credential Theft
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="Data Exfiltration">
+                
+                Data Exfiltration
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/wscript.exe.html" class="tool-item" data-id="wscript.exe">
+        <div class="tool-title">wscript.exe</div>
         <div class="tool-tags">
             <span class="tool-tag platform-tag" data-platform="Windows">
                 
@@ -1608,7 +1543,37 @@
             
             <span class="tool-tag capability-tag" data-capability="UAC">
                 
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
+                
+            </span>
+            
+            <div class="tool-lure-count">2 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/mshta.exe.html" class="tool-item" data-id="mshta.exe">
+        <div class="tool-title">mshta.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="MOTW">
+                
+                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="UAC">
+                
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 
             </span>
             
@@ -1640,8 +1605,8 @@
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/wscript.exe.html" class="tool-item" data-id="wscript.exe">
-        <div class="tool-title">wscript.exe</div>
+    <a href="/ClickGrab/techniques/msbuild.exe.html" class="tool-item" data-id="msbuild.exe">
+        <div class="tool-title">msbuild.exe</div>
         <div class="tool-tags">
             <span class="tool-tag platform-tag" data-platform="Windows">
                 
@@ -1662,7 +1627,7 @@
             
             <span class="tool-tag capability-tag" data-capability="UAC">
                 
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 
             </span>
             
@@ -1670,8 +1635,38 @@
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/colorcpl.exe.html" class="tool-item" data-id="colorcpl.exe">
-        <div class="tool-title">colorcpl.exe</div>
+    <a href="/ClickGrab/techniques/perfmon.exe.html" class="tool-item" data-id="perfmon.exe">
+        <div class="tool-title">perfmon.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/MRT.exe.html" class="tool-item" data-id="MRT.exe">
+        <div class="tool-title">MRT.exe</div>
         <div class="tool-tags">
             <span class="tool-tag platform-tag" data-platform="Windows">
                 
@@ -1696,12 +1691,18 @@
                 
             </span>
             
+            <span class="tool-tag capability-tag" data-capability="UAC">
+                
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
+                
+            </span>
+            
             <div class="tool-lure-count">2 lures</div>
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/msra.exe.html" class="tool-item" data-id="msra.exe">
-        <div class="tool-title">msra.exe</div>
+    <a href="/ClickGrab/techniques/DxDiag.exe.html" class="tool-item" data-id="DxDiag.exe">
+        <div class="tool-title">DxDiag.exe</div>
         <div class="tool-tags">
             <span class="tool-tag platform-tag" data-platform="Windows">
                 
@@ -1727,6 +1728,30 @@
             </span>
             
             <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/cmd.exe.html" class="tool-item" data-id="cmd.exe">
+        <div class="tool-title">cmd.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="UAC">
+                
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
+                
+            </span>
+            
+            <div class="tool-lure-count">2 lures</div>
         </div>
     </a>
     

--- a/docs/techniques/CompMgmtLauncher.exe.html
+++ b/docs/techniques/CompMgmtLauncher.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CompMgmtLauncher.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -513,7 +547,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -606,7 +640,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -675,7 +709,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -746,7 +780,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/docs/techniques/DxDiag.exe.html
+++ b/docs/techniques/DxDiag.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>DxDiag.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,13 +505,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
@@ -512,13 +546,13 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/docs/techniques/FileHistory.exe.html
+++ b/docs/techniques/FileHistory.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>FileHistory.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -467,19 +501,19 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -514,13 +548,13 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
@@ -580,19 +614,19 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/docs/techniques/MRT.exe.html
+++ b/docs/techniques/MRT.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MRT.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,19 +505,19 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -520,19 +554,19 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -608,19 +642,19 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/docs/techniques/Terminal.html
+++ b/docs/techniques/Terminal.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Terminal - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/docs/techniques/certreq.exe.html
+++ b/docs/techniques/certreq.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>certreq.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -467,19 +501,19 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -516,13 +550,13 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -589,19 +623,19 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/docs/techniques/certutil.exe.html
+++ b/docs/techniques/certutil.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>certutil.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,13 +505,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -513,7 +547,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
@@ -621,7 +655,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/docs/techniques/clickonce.html
+++ b/docs/techniques/clickonce.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ClickOnce launcher (dfshim) - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/docs/techniques/cmd.exe.html
+++ b/docs/techniques/cmd.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>cmd.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -467,7 +501,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -586,7 +620,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/docs/techniques/colorcpl.exe.html
+++ b/docs/techniques/colorcpl.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>colorcpl.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -467,13 +501,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
@@ -508,13 +542,13 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
@@ -598,13 +632,13 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 

--- a/docs/techniques/conhost.exe.html
+++ b/docs/techniques/conhost.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>conhost.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -467,7 +501,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -580,7 +614,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/docs/techniques/consentfix.html
+++ b/docs/techniques/consentfix.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ConsentFix - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/docs/techniques/control.exe.html
+++ b/docs/techniques/control.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>control.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -483,13 +517,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -524,13 +558,13 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -588,19 +622,19 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 
@@ -666,7 +700,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/docs/techniques/crashfix.html
+++ b/docs/techniques/crashfix.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CrashFix - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/docs/techniques/credwiz.exe.html
+++ b/docs/techniques/credwiz.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>credwiz.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,19 +505,19 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -520,13 +554,13 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -593,19 +627,19 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/docs/techniques/dcomcnfg.exe.html
+++ b/docs/techniques/dcomcnfg.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>dcomcnfg.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -513,7 +547,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/docs/techniques/eventvwr.exe.html
+++ b/docs/techniques/eventvwr.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>eventvwr.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -512,7 +546,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -590,7 +624,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/docs/techniques/explorer-shell-uris.html
+++ b/docs/techniques/explorer-shell-uris.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>explorer shell URIs - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -512,7 +546,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -588,7 +622,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/docs/techniques/fake-google-meet.html
+++ b/docs/techniques/fake-google-meet.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Fake Google Meet ClickFix - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/docs/techniques/filefix.html
+++ b/docs/techniques/filefix.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>FileFix (Explorer address bar) - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -477,7 +511,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -519,7 +553,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -615,7 +649,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -691,7 +725,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/docs/techniques/finger.exe.html
+++ b/docs/techniques/finger.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>finger.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/docs/techniques/forfiles.exe.html
+++ b/docs/techniques/forfiles.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>forfiles.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -477,7 +511,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -605,7 +639,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -688,7 +722,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -771,7 +805,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/docs/techniques/fsquirt.exe.html
+++ b/docs/techniques/fsquirt.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>fsquirt.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -513,7 +547,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/docs/techniques/ftp.exe.html
+++ b/docs/techniques/ftp.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ftp.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -472,7 +506,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -586,7 +620,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/docs/techniques/iexpress.exe.html
+++ b/docs/techniques/iexpress.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>iexpress.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -512,7 +546,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/docs/techniques/msbuild.exe.html
+++ b/docs/techniques/msbuild.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>msbuild.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,13 +505,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -513,7 +547,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
@@ -619,7 +653,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/docs/techniques/mshta.exe.html
+++ b/docs/techniques/mshta.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>mshta.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,13 +505,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -513,7 +547,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
@@ -621,7 +655,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/docs/techniques/msiexec.exe.html
+++ b/docs/techniques/msiexec.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>msiexec.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/docs/techniques/msra.exe.html
+++ b/docs/techniques/msra.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>msra.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,13 +505,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
@@ -514,13 +548,13 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/docs/techniques/net-use-webdav.html
+++ b/docs/techniques/net-use-webdav.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>net use (WebDAV) - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/docs/techniques/nslookup.exe.html
+++ b/docs/techniques/nslookup.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>nslookup.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/docs/techniques/office-uri.html
+++ b/docs/techniques/office-uri.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Office URI schemes (ms-word/ms-excel) - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -519,7 +553,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/docs/techniques/osascript.html
+++ b/docs/techniques/osascript.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>osascript - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/docs/techniques/perfmon.exe.html
+++ b/docs/techniques/perfmon.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>perfmon.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -512,7 +546,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/docs/techniques/powershell.exe.html
+++ b/docs/techniques/powershell.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>powershell.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,13 +505,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -513,7 +547,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
@@ -623,7 +657,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/docs/techniques/regasm.exe.html
+++ b/docs/techniques/regasm.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>regasm.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,13 +505,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -513,7 +547,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
@@ -619,7 +653,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/docs/techniques/rundll32.exe.html
+++ b/docs/techniques/rundll32.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>rundll32.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,13 +505,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -513,7 +547,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
@@ -619,7 +653,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/docs/techniques/search-ms.html
+++ b/docs/techniques/search-ms.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>search-ms protocol - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -512,7 +546,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/docs/techniques/ssh.exe.html
+++ b/docs/techniques/ssh.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ssh.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -477,7 +511,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -519,7 +553,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/docs/techniques/steganography-clickfix.html
+++ b/docs/techniques/steganography-clickfix.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Steganography ClickFix (Stego Loader) - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/docs/techniques/taskmgr.exe.html
+++ b/docs/techniques/taskmgr.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>taskmgr.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -512,7 +546,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/docs/techniques/wextract.exe.html
+++ b/docs/techniques/wextract.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>wextract.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -477,7 +511,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -518,7 +552,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/docs/techniques/wscript.exe.html
+++ b/docs/techniques/wscript.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>wscript.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,13 +505,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -513,7 +547,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
@@ -619,7 +653,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/docs/techniques/wt.exe.html
+++ b/docs/techniques/wt.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>wt.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/docs/techniques/wusa.exe.html
+++ b/docs/techniques/wusa.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>wusa.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/public/analysis.html
+++ b/public/analysis.html
@@ -5,30 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ClickGrab - Threat Intelligence Analysis</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <style>
     /* Blog-specific styles */
     .analysis-hero {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: linear-gradient(135deg, var(--surface) 0%, var(--surface-3) 100%);
+        color: var(--text);
         text-align: center;
         padding: 4rem 2rem;
         border-radius: var(--border-radius);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
         margin-bottom: 3rem;
-        box-shadow: var(--shadow-lg);
+        box-shadow: var(--shadow);
         position: relative;
         overflow: hidden;
     }
-    
+
     .analysis-hero::before {
         content: '';
         position: absolute;
@@ -36,205 +35,217 @@
         left: 0;
         right: 0;
         bottom: 0;
-        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="20" cy="20" r="2" fill="rgba(255,255,255,0.1)"/><circle cx="80" cy="40" r="1.5" fill="rgba(255,255,255,0.1)"/><circle cx="40" cy="60" r="1" fill="rgba(255,255,255,0.1)"/><circle cx="70" cy="80" r="2.5" fill="rgba(255,255,255,0.1)"/></svg>') repeat;
+        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="20" cy="20" r="2" fill="rgba(0,255,136,0.08)"/><circle cx="80" cy="40" r="1.5" fill="rgba(0,255,136,0.08)"/><circle cx="40" cy="60" r="1" fill="rgba(0,255,136,0.08)"/><circle cx="70" cy="80" r="2.5" fill="rgba(0,255,136,0.08)"/></svg>') repeat;
         pointer-events: none;
     }
-    
+
     .analysis-hero .content {
         position: relative;
         z-index: 1;
     }
-    
+
     .analysis-hero h1 {
         font-size: 3rem;
         margin-bottom: 1rem;
         border-bottom: none;
-        color: white;
-        background: linear-gradient(45deg, #fff, #f0f8ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 2px;
+        color: var(--accent);
     }
-    
+
     .analysis-hero p {
         font-size: 1.3rem;
         opacity: 1;
         max-width: 600px;
         margin: 0 auto;
-        color: rgba(255, 255, 255, 0.95);
-        text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+        color: var(--text-soft);
         font-weight: 400;
     }
-    
+
     /* Key Insights Section */
     .key-insights {
-        background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
-        border-radius: 16px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 2rem;
         margin-bottom: 3rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border: 1px solid #e2e8f0;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
     }
-    
+
     .insights-header {
         display: flex;
         align-items: center;
         gap: 1rem;
         margin-bottom: 1.5rem;
     }
-    
+
     .insights-icon {
         width: 48px;
         height: 48px;
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        border-radius: 12px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         display: flex;
         align-items: center;
         justify-content: center;
         font-size: 24px;
     }
-    
+
     .insights-title {
         font-size: 1.75rem;
-        font-weight: 700;
-        color: var(--text-color);
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
     }
-    
+
     .insights-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
         gap: 1.5rem;
     }
-    
+
     .insight-item {
         text-align: center;
         padding: 1.5rem;
-        background: white;
-        border-radius: 12px;
-        border: 1px solid #e2e8f0;
-        transition: all 0.3s ease;
+        background: var(--surface-2);
+        border-radius: var(--border-radius);
+        border: 1px solid var(--border);
+        transition: all 0.18s ease;
     }
-    
+
     .insight-item:hover {
         transform: translateY(-3px);
-        box-shadow: 0 8px 20px rgba(0,0,0,0.1);
+        border-color: var(--accent);
+        box-shadow: var(--shadow);
     }
-    
+
     .insight-value {
         font-size: 2.5rem;
+        font-family: var(--font-mono);
         font-weight: 700;
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
         display: block;
         margin-bottom: 0.5rem;
     }
-    
+
     .insight-label {
         font-size: 0.9rem;
-        color: var(--text-light);
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        color: var(--muted);
         font-weight: 500;
     }
-    
+
     /* Search and Filter Bar */
     .analysis-controls {
-        background: white;
-        border-radius: 16px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 1.5rem;
         margin-bottom: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border: 1px solid #e2e8f0;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
     }
-    
+
     .controls-row {
         display: flex;
         gap: 1rem;
         align-items: center;
         flex-wrap: wrap;
     }
-    
+
     .search-box {
         flex: 2;
         position: relative;
         min-width: 300px;
     }
-    
+
     .search-input {
         width: 100%;
         padding: 0.75rem 1rem 0.75rem 3rem;
-        border: 2px solid #e2e8f0;
-        border-radius: 10px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        color: var(--text);
         font-size: 1rem;
-        transition: all 0.3s ease;
+        transition: all 0.18s ease;
     }
-    
+
+    .search-input::placeholder {
+        color: var(--muted);
+    }
+
     .search-input:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
-    
+
     .search-icon {
         position: absolute;
         left: 1rem;
         top: 50%;
         transform: translateY(-50%);
-        color: #94a3b8;
+        color: var(--muted);
     }
-    
+
     .filter-chips {
         display: flex;
         gap: 0.5rem;
         flex-wrap: wrap;
         flex: 1;
     }
-    
+
     .filter-chip {
         padding: 0.5rem 1rem;
-        background: #f1f5f9;
-        border: 2px solid transparent;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
         border-radius: 20px;
+        font-family: var(--font-mono);
         font-size: 0.9rem;
         font-weight: 500;
         cursor: pointer;
-        transition: all 0.3s ease;
-        color: var(--text-light);
+        transition: all 0.18s ease;
+        color: var(--text-soft);
     }
-    
+
     .filter-chip:hover {
-        background: #e2e8f0;
+        background: var(--surface-3);
+        border-color: var(--accent);
     }
-    
+
     .filter-chip.active {
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        color: white;
-        border-color: transparent;
+        background: var(--accent);
+        color: var(--bg);
+        border-color: var(--accent);
     }
-    
+
     .blog-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
         gap: 2rem;
         margin-bottom: 3rem;
     }
-    
+
     .blog-card {
-        background: white;
-        border-radius: 12px;
-        box-shadow: 0 8px 32px rgba(0,0,0,0.12);
+        background: var(--surface);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
         overflow: hidden;
-        transition: all 0.3s ease;
-        border: 1px solid rgba(255,255,255,0.2);
+        transition: all 0.18s ease;
+        border: 1px solid var(--border);
         position: relative;
         opacity: 0;
         animation: fadeInUp 0.6s ease forwards;
     }
-    
+
     .blog-card:nth-child(1) { animation-delay: 0.1s; }
     .blog-card:nth-child(2) { animation-delay: 0.2s; }
     .blog-card:nth-child(3) { animation-delay: 0.3s; }
-    
+
     @keyframes fadeInUp {
         from {
             opacity: 0;
@@ -245,189 +256,214 @@
             transform: translateY(0);
         }
     }
-    
+
     .blog-card:hover {
         transform: translateY(-8px);
-        box-shadow: 0 20px 40px rgba(0,0,0,0.15);
+        border-color: var(--accent);
+        box-shadow: var(--shadow);
     }
-    
+
     .blog-card::before {
         content: '';
         position: absolute;
         top: 0;
         left: 0;
         right: 0;
-        height: 4px;
-        background: linear-gradient(90deg, var(--primary-color), var(--accent-color));
+        height: 3px;
+        background: var(--accent);
+        z-index: 1;
     }
-    
+
     .blog-header {
-        background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+        background: var(--surface-2);
         padding: 1.5rem;
-        border-bottom: 1px solid #e2e8f0;
+        border-bottom: 1px solid var(--border);
     }
-    
+
     .blog-meta {
         display: flex;
         align-items: center;
         gap: 1rem;
         margin-bottom: 1rem;
         font-size: 0.9rem;
-        color: var(--text-light);
+        color: var(--muted);
     }
-    
+
     .blog-date {
-        background: var(--primary-color);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent);
+        font-family: var(--font-mono);
         padding: 0.25rem 0.75rem;
         border-radius: 20px;
         font-weight: 500;
         font-size: 0.8rem;
     }
-    
+
     .blog-category {
-        background: linear-gradient(45deg, #ff6b6b, #ee5a24);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent3);
+        color: var(--accent3);
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
         padding: 0.25rem 0.75rem;
         border-radius: 20px;
         font-weight: 500;
         font-size: 0.8rem;
     }
-    
+
     .blog-title {
         font-size: 1.5rem;
-        font-weight: 700;
-        color: var(--text-color);
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin-bottom: 0.5rem;
         line-height: 1.3;
     }
-    
+
     .blog-excerpt {
-        color: var(--text-light);
+        color: var(--text-soft);
         line-height: 1.6;
         font-size: 1rem;
     }
-    
+
     .blog-content {
         padding: 1.5rem;
     }
-    
+
     .blog-stats {
         display: flex;
         gap: 1.5rem;
         margin-bottom: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .blog-stat {
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        color: white;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-top: 2px solid var(--accent);
+        color: var(--text);
         padding: 0.75rem 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         text-align: center;
         flex: 1;
         min-width: 80px;
     }
-    
+
     .blog-stat-number {
         font-size: 1.5rem;
+        font-family: var(--font-mono);
         font-weight: 700;
+        color: var(--accent);
         display: block;
     }
-    
+
     .blog-stat-label {
         font-size: 0.75rem;
-        opacity: 0.9;
+        font-family: var(--font-mono);
+        color: var(--muted);
         text-transform: uppercase;
         letter-spacing: 0.5px;
     }
-    
+
     .blog-tags {
         display: flex;
         flex-wrap: wrap;
         gap: 0.5rem;
         margin-bottom: 1.5rem;
     }
-    
+
     .blog-tag {
-        background: linear-gradient(45deg, #22c55e, #0891b2);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent);
+        font-family: var(--font-mono);
         padding: 0.25rem 0.75rem;
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
     }
-    
+
     .blog-actions {
         display: flex;
         gap: 1rem;
         align-items: center;
     }
-    
+
     .read-more {
-        background: linear-gradient(45deg, var(--primary-color), #4c51bf);
-        color: white;
+        background: var(--accent);
+        color: var(--bg);
         padding: 0.75rem 1.5rem;
-        border-radius: 25px;
+        border-radius: var(--border-radius);
         text-decoration: none;
+        font-family: var(--font-mono);
         font-weight: 600;
-        transition: all 0.3s ease;
-        box-shadow: 0 4px 15px rgba(37, 99, 235, 0.3);
+        letter-spacing: 0.5px;
+        transition: all 0.18s ease;
         flex: 1;
         text-align: center;
     }
-    
+
     .read-more:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(37, 99, 235, 0.4);
-        color: white;
+        background: var(--accent-dim);
+        color: var(--bg);
     }
-    
+
     .share-btn {
-        background: linear-gradient(45deg, #48bb78, #38a169);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent);
         padding: 0.75rem;
         border-radius: 50%;
         text-decoration: none;
-        transition: all 0.3s ease;
+        transition: all 0.18s ease;
         width: 45px;
         height: 45px;
         display: flex;
         align-items: center;
         justify-content: center;
     }
-    
+
     .share-btn:hover {
         transform: rotate(5deg) scale(1.1);
-        color: white;
+        border-color: var(--accent);
+        color: var(--accent);
     }
-    
+
     .featured-badge {
         position: absolute;
         top: 1rem;
         right: 1rem;
-        background: linear-gradient(45deg, #ffd700, #ffed4e);
-        color: #000;
+        background: var(--accent4);
+        color: var(--bg);
         padding: 0.5rem 1rem;
         border-radius: 20px;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
         font-size: 0.8rem;
         font-weight: 700;
         z-index: 2;
-        box-shadow: 0 4px 15px rgba(255, 215, 0, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     /* Newsletter Signup */
     .newsletter-section {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        border-radius: 16px;
+        background: linear-gradient(135deg, var(--surface) 0%, var(--surface-3) 100%);
+        border-radius: var(--border-radius);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
         padding: 3rem 2rem;
         margin: 3rem 0;
         text-align: center;
-        color: white;
+        color: var(--text);
         position: relative;
         overflow: hidden;
     }
-    
+
     .newsletter-section::before {
         content: '';
         position: absolute;
@@ -435,34 +471,36 @@
         right: -50%;
         width: 200%;
         height: 200%;
-        background: radial-gradient(circle, rgba(255,255,255,0.1) 0%, transparent 70%);
+        background: radial-gradient(circle, rgba(0,255,136,0.06) 0%, transparent 70%);
         animation: pulse 15s ease-in-out infinite;
     }
-    
+
     @keyframes pulse {
         0%, 100% { transform: scale(0.8); opacity: 0.5; }
         50% { transform: scale(1.2); opacity: 0.8; }
     }
-    
+
     .newsletter-content {
         position: relative;
         z-index: 1;
     }
-    
+
     .newsletter-title {
         font-size: 2rem;
         margin-bottom: 1rem;
-        font-weight: 700;
-        color: white;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent);
     }
-    
+
     .newsletter-desc {
         font-size: 1.1rem;
         margin-bottom: 2rem;
         opacity: 1;
-        color: white;
+        color: var(--text-soft);
     }
-    
+
     .newsletter-form {
         display: flex;
         gap: 1rem;
@@ -471,71 +509,72 @@
         flex-wrap: wrap;
         justify-content: center;
     }
-    
+
     .newsletter-input {
         flex: 1;
         min-width: 250px;
         padding: 0.75rem 1.5rem;
-        border: 2px solid rgba(255,255,255,0.3);
+        border: 1px solid var(--border);
         border-radius: 30px;
-        background: rgba(255,255,255,0.1);
-        color: white;
+        background: var(--surface-2);
+        color: var(--text);
         font-size: 1rem;
-        transition: all 0.3s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .newsletter-input::placeholder {
-        color: rgba(255,255,255,0.7);
+        color: var(--muted);
     }
-    
+
     .newsletter-input:focus {
         outline: none;
-        border-color: white;
-        background: rgba(255,255,255,0.2);
+        border-color: var(--accent);
+        background: var(--surface-3);
     }
-    
+
     .newsletter-submit {
         padding: 0.75rem 2rem;
-        background: white;
-        color: #0e7490;
+        background: var(--accent);
+        color: var(--bg);
         border: none;
         border-radius: 30px;
+        font-family: var(--font-mono);
         font-weight: 600;
+        letter-spacing: 0.5px;
         font-size: 1rem;
         cursor: pointer;
-        transition: all 0.3s ease;
-        box-shadow: 0 4px 15px rgba(0,0,0,0.2);
+        transition: all 0.18s ease;
     }
-    
+
     .newsletter-submit:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(0,0,0,0.3);
+        background: var(--accent-dim);
     }
-    
+
     .coming-soon {
         text-align: center;
         padding: 3rem 2rem;
-        background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
-        border-radius: 12px;
-        border: 2px dashed #cbd5e0;
+        background: var(--surface-2);
+        border-radius: var(--border-radius);
+        border: 2px dashed var(--border);
         margin-top: 2rem;
     }
-    
+
     .coming-soon h3 {
-        color: var(--text-light);
+        color: var(--text-soft);
         margin-bottom: 1rem;
     }
-    
+
     .coming-soon p {
-        color: var(--text-light);
+        color: var(--muted);
         font-style: italic;
     }
-    
+
     /* No Results */
     .no-results {
         text-align: center;
         padding: 3rem;
-        color: var(--text-light);
+        color: var(--muted);
         display: none;
     }
     
@@ -1157,7 +1196,7 @@
     <h2>About Our Analysis</h2>
     <p>Our threat intelligence analysis goes beyond automated reporting to provide deep technical insights into emerging attack patterns, obfuscation techniques, and defensive strategies. Each analysis includes:</p>
     
-    <ul style="margin-left: 2rem; color: var(--text-light);">
+    <ul style="margin-left: 2rem; color: var(--text-soft);">
         <li><strong>Technical Deep Dives:</strong> Detailed examination of attack methodologies and code analysis</li>
         <li><strong>Threat Actor Profiling:</strong> Infrastructure analysis and campaign attribution</li>
         <li><strong>Defensive Strategies:</strong> Actionable recommendations and detection rules</li>
@@ -1295,7 +1334,7 @@ function handleNewsletterSubmit(event) {
     // If they come back to the page with ?subscribed=true, show success
     if (window.location.search.includes('subscribed=true')) {
         submitBtn.textContent = '✓ Subscribed!';
-        submitBtn.style.background = '#22c55e';
+        submitBtn.style.background = 'var(--accent)';
         setTimeout(() => {
             submitBtn.textContent = 'Subscribe';
             submitBtn.style.background = '';

--- a/public/analysis/clickgrab-analysis-2026-06-01.html
+++ b/public/analysis/clickgrab-analysis-2026-06-01.html
@@ -5,35 +5,35 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Emerging ClickGrab Campaign: Advanced Analysis of 2026-06-01 Attack Patterns - ClickGrab Threat Intelligence</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <style>
     /* Blog post specific styles */
     .article-container {
         max-width: 900px;
         margin: 0 auto;
-        background: white;
-        border-radius: 12px;
-        box-shadow: var(--shadow-lg);
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
         overflow: hidden;
     }
-    
+
     .article-header {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: linear-gradient(135deg, var(--surface-2) 0%, var(--surface-3) 100%);
+        color: var(--text);
+        border-bottom: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
         padding: 3rem 2rem;
         text-align: center;
         position: relative;
     }
-    
+
     .article-header::before {
         content: '';
         position: absolute;
@@ -41,23 +41,26 @@
         left: 0;
         right: 0;
         bottom: 0;
-        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="20" cy="20" r="2" fill="rgba(255,255,255,0.1)"/><circle cx="80" cy="40" r="1.5" fill="rgba(255,255,255,0.1)"/><circle cx="40" cy="60" r="1" fill="rgba(255,255,255,0.1)"/><circle cx="70" cy="80" r="2.5" fill="rgba(255,255,255,0.1)"/></svg>') repeat;
+        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="20" cy="20" r="2" fill="rgba(0,255,136,0.12)"/><circle cx="80" cy="40" r="1.5" fill="rgba(0,255,136,0.12)"/><circle cx="40" cy="60" r="1" fill="rgba(0,255,136,0.12)"/><circle cx="70" cy="80" r="2.5" fill="rgba(0,255,136,0.12)"/></svg>') repeat;
         pointer-events: none;
     }
-    
+
     .article-header .content {
         position: relative;
         z-index: 1;
     }
-    
+
     .article-title {
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1.5px;
         font-size: 2.5rem;
         margin-bottom: 1rem;
         line-height: 1.2;
         border-bottom: none;
-        color: white;
+        color: var(--accent);
     }
-    
+
     .article-meta {
         display: flex;
         justify-content: center;
@@ -72,22 +75,26 @@
         margin-top: 1.25rem;
     }
     .hero-metric {
-        background: rgba(255,255,255,0.15);
-        border: 1px solid rgba(255,255,255,0.25);
-        color: white;
-        border-radius: 10px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
+        border-radius: var(--border-radius);
         padding: 0.75rem 1rem;
     }
-    .hero-metric .num { font-weight: 800; font-size: 1.4rem; display:block; }
-    .hero-metric .lbl { opacity: 0.95; font-size: 0.8rem; }
-    
+    .hero-metric .num { font-family: var(--font-mono); font-weight: 700; font-size: 1.4rem; display:block; color: var(--accent); }
+    .hero-metric .lbl { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 1px; color: var(--muted); font-size: 0.8rem; }
+
     .meta-item {
-        background: rgba(255,255,255,0.2);
+        font-family: var(--font-mono);
+        background: var(--surface);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
         padding: 0.5rem 1rem;
-        border-radius: 25px;
+        border-radius: 999px;
         font-size: 0.9rem;
     }
-    
+
     .article-content {
         padding: 3rem;
         line-height: 1.8;
@@ -97,189 +104,215 @@
     .toc-layout { display: grid; grid-template-columns: 1fr 260px; gap: 2rem; }
     .toc-sidebar {
         position: sticky; top: 100px; align-self: start; height: max-content;
-        background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 12px; padding: 1rem;
+        background: var(--surface-2); border: 1px solid var(--border);
+        border-left: 3px solid var(--accent); border-radius: var(--border-radius); padding: 1rem;
     }
-    .toc-title { font-weight: 700; margin: 0 0 0.5rem 0; font-size: 0.95rem; color: #334155; }
+    .toc-title { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 1px; font-weight: 700; margin: 0 0 0.5rem 0; font-size: 0.95rem; color: var(--accent); }
     .toc-list { list-style: none; margin: 0; padding: 0; }
     .toc-list li { margin: 0.25rem 0; }
-    .toc-link { color: #64748b; text-decoration: none; font-size: 0.9rem; }
-    .toc-link.active { color: #4f46e5; font-weight: 600; }
-    
+    .toc-link { color: var(--muted); text-decoration: none; font-size: 0.9rem; transition: color 0.18s ease; }
+    .toc-link:hover { color: var(--text-soft); }
+    .toc-link.active { color: var(--accent); font-weight: 600; }
+
     .article-content h2 {
-        color: var(--primary-color);
+        color: var(--accent);
         margin-top: 3rem;
         margin-bottom: 1.5rem;
         font-size: 1.8rem;
-        border-bottom: 2px solid var(--primary-color);
+        border-bottom: 1px solid var(--border);
         padding-bottom: 0.5rem;
     }
-    
+
     .article-content h3 {
-        color: var(--secondary-color);
+        color: var(--accent3);
         margin-top: 2rem;
         margin-bottom: 1rem;
         font-size: 1.4rem;
     }
-    
+
     .article-content h4 {
-        color: var(--text-color);
+        color: var(--text);
         margin-top: 1.5rem;
         margin-bottom: 0.75rem;
         font-size: 1.2rem;
     }
-    
+
     .article-content p {
         margin-bottom: 1.5rem;
-        color: var(--text-color);
+        color: var(--text-soft);
     }
-    
+
     .article-content ul, .article-content ol {
         margin-bottom: 1.5rem;
         padding-left: 2rem;
     }
-    
+
     .article-content li {
         margin-bottom: 0.5rem;
-        color: var(--text-color);
+        color: var(--text-soft);
     }
-    
+
     .article-content table {
         width: 100%;
         border-collapse: collapse;
         margin: 2rem 0;
-        background: #f8fafc;
-        border-radius: 8px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         overflow: hidden;
     }
-    
+
     .article-content th,
     .article-content td {
         padding: 1rem;
         text-align: left;
-        border-bottom: 1px solid #e2e8f0;
+        border-bottom: 1px solid var(--border);
+        color: var(--text-soft);
     }
-    
+
     .article-content th {
-        background: var(--primary-color);
-        color: white;
+        background: var(--surface-2);
+        color: var(--accent);
+        border-bottom: 2px solid var(--accent);
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         font-weight: 600;
     }
-    
+
     .article-content tr:hover {
-        background: #f1f5f9;
+        background: var(--highlight);
     }
-    
+
     .article-content pre {
-        background: #1a202c;
-        color: #e2e8f0;
+        background: #05050a;
+        color: var(--text-soft);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
         padding: 1.5rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         overflow-x: auto;
         margin: 1.5rem 0;
         line-height: 1.6;
+        font-family: var(--font-mono);
     }
-    
+
     .article-content code {
-        background: #f1f5f9;
-        color: #e53e3e;
+        background: var(--surface-3);
+        color: var(--accent3);
         padding: 0.25rem 0.5rem;
-        border-radius: 4px;
-        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+        border-radius: var(--border-radius);
+        font-family: var(--font-mono);
         font-size: 0.9em;
     }
-    
+
     .article-content pre code {
         background: none;
         color: inherit;
         padding: 0;
     }
-    
+
     .highlight-box {
-        background: linear-gradient(135deg, #fff5f5 0%, #fed7d7 100%);
-        border-left: 4px solid #e53e3e;
+        background: var(--surface-2);
+        border-left: 4px solid var(--accent2);
         padding: 1.5rem;
         margin: 2rem 0;
-        border-radius: 0 8px 8px 0;
+        border-radius: 0 var(--border-radius) var(--border-radius) 0;
+        color: var(--text-soft);
     }
-    
+
     .info-box {
-        background: linear-gradient(135deg, #ebf8ff 0%, #bee3f8 100%);
-        border-left: 4px solid var(--primary-color);
+        background: var(--surface-2);
+        border-left: 4px solid var(--accent3);
         padding: 1.5rem;
         margin: 2rem 0;
-        border-radius: 0 8px 8px 0;
+        border-radius: 0 var(--border-radius) var(--border-radius) 0;
+        color: var(--text-soft);
     }
-    
+
     .stats-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
         gap: 1.5rem;
         margin: 2rem 0;
     }
-    
+
     .stat-item {
-        background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         text-align: center;
     }
-    
+
     .stat-number {
+        font-family: var(--font-mono);
         font-size: 2rem;
         font-weight: 700;
+        color: var(--accent);
         display: block;
         margin-bottom: 0.5rem;
     }
-    
+
     .stat-label {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         font-size: 0.9rem;
-        opacity: 0.9;
+        color: var(--muted);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: var(--primary-color);
+        font-family: var(--font-mono);
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
         margin-bottom: 2rem;
-        transition: all 0.3s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .back-link:hover {
         transform: translateX(-5px);
+        color: var(--accent-dim);
     }
-    
+
     .article-footer {
-        background: #f8fafc;
+        background: var(--surface-2);
         padding: 2rem;
-        border-top: 1px solid #e2e8f0;
+        border-top: 1px solid var(--border);
         text-align: center;
+        color: var(--text-soft);
     }
-    
+
     .share-buttons {
         display: flex;
         justify-content: center;
         gap: 1rem;
         margin-top: 1rem;
     }
-    
+
     .share-btn-footer {
-        background: var(--primary-color);
-        color: white;
+        font-family: var(--font-mono);
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent);
         padding: 0.75rem 1.5rem;
-        border-radius: 25px;
+        border-radius: 999px;
         text-decoration: none;
         font-weight: 600;
-        transition: all 0.3s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .share-btn-footer:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(37, 99, 235, 0.3);
-        color: white;
+        border-color: var(--accent);
+        box-shadow: var(--shadow);
+        color: var(--accent);
     }
     
     @media (max-width: 768px) {

--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -1,280 +1,289 @@
-/* ClickGrab Styles */
+/* =========================================================================
+   ClickGrab — "Hunt in the Dark" design system
+   Hacker-terminal aesthetic, aligned with the BSides deck:
+   JetBrains Mono / Bebas Neue / Inter, near-black canvas, neon-green accent.
+   Fonts are loaded via <link> in base.html.
+   ========================================================================= */
+
 :root {
-    --primary-color: #0e7490;
-    --secondary-color: #0f766e;
-    --accent-color: #22c55e;
-    --text-color: #0f172a;
-    --text-light: #475569;
-    --background-color: #f4f8fb;
-    --danger-color: #ef4444;
-    --warning-color: #f59e0b;
-    --success-color: #22c55e;
-    --border-radius: 10px;
-    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-    --shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
-    --shadow-lg: 0 16px 36px rgba(15, 23, 42, 0.12);
+    /* --- Core palette (from the deck) --- */
+    --bg: #0a0a0f;
+    --surface: #0f0f1a;
+    --surface-2: #13131f;
+    --surface-3: #181826;
+    --border: #1e1e35;
+    --border-soft: #181830;
+
+    --accent: #00ff88;        /* neon green   */
+    --accent-dim: #00cc6a;
+    --accent2: #ff3366;       /* alert red    */
+    --accent3: #3d9eff;       /* info blue    */
+    --accent4: #ffcc00;       /* warning gold */
+
+    --text: #e8e8f0;
+    --text-soft: #c8c8d8;
+    --muted: #6b6b8a;
+    --highlight: rgba(0, 255, 136, 0.08);
+
+    /* --- Back-compat aliases (old templates reference these var names) --- */
+    --primary-color: var(--accent);
+    --secondary-color: var(--accent-dim);
+    --accent-color: var(--accent);
+    --text-color: var(--text);
+    --text-light: var(--muted);
+    --background-color: var(--bg);
+    --danger-color: var(--accent2);
+    --warning-color: var(--accent4);
+    --success-color: var(--accent);
+
+    --border-radius: 4px;
+    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.4);
+    --shadow: 0 12px 30px rgba(0, 0, 0, 0.5);
+    --shadow-lg: 0 20px 50px rgba(0, 0, 0, 0.6);
+
     --font-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    --font-display: 'Bebas Neue', 'Inter', sans-serif;
 }
 
-/* Base styles */
-* {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { scroll-behavior: smooth; }
 
 body {
     font-family: var(--font-sans);
-    line-height: 1.6;
-    color: var(--text-color);
-    background: linear-gradient(180deg, #f8fbfe 0%, var(--background-color) 280px);
+    line-height: 1.65;
+    color: var(--text);
+    background: var(--bg);
     font-size: 16px;
+    position: relative;
+    min-height: 100vh;
+    overflow-x: hidden;
+}
+
+/* Fixed background layers — grid + scanlines + glow, on every page */
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: -2;
+    background-image:
+        linear-gradient(rgba(0, 255, 136, 0.035) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 255, 136, 0.035) 1px, transparent 1px);
+    background-size: 42px 42px;
+    pointer-events: none;
+}
+body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: -2;
+    background:
+        radial-gradient(620px circle at 12% -5%, rgba(0, 255, 136, 0.10), transparent 60%),
+        radial-gradient(560px circle at 92% 0%, rgba(61, 158, 255, 0.10), transparent 55%);
+    pointer-events: none;
 }
 
 a {
-    color: var(--primary-color);
+    color: var(--accent);
     text-decoration: none;
-    transition: color 0.2s ease, transform 0.2s ease;
+    transition: color 0.18s ease, opacity 0.18s ease;
 }
-
-a:hover {
-    color: var(--secondary-color);
-}
+a:hover { color: var(--accent3); }
 
 .container {
-    width: 90%;
+    width: 92%;
     max-width: 1200px;
     margin: 0 auto;
     padding: 0 15px;
 }
 
-/* Typography */
+/* ---------------------------------------------------------------- Typography */
 h1, h2, h3, h4, h5, h6 {
     margin-bottom: 1rem;
-    color: var(--text-color);
+    color: var(--text);
     font-weight: 700;
-    line-height: 1.2;
+    line-height: 1.15;
+    letter-spacing: 0.3px;
 }
 
 h1 {
-    font-size: 2.25rem;
-    border-bottom: 2px solid var(--primary-color);
-    padding-bottom: 0.75rem;
-    margin-bottom: 1.5rem;
+    font-family: var(--font-display);
+    font-size: clamp(2.2rem, 4.4vw, 3.4rem);
+    letter-spacing: 3px;
+    font-weight: 400;
+    padding-bottom: 0.6rem;
+    margin-bottom: 1.4rem;
+    border-bottom: 1px solid var(--border);
+}
+h1::after {
+    content: '';
+    display: block;
+    width: 64px;
+    height: 2px;
+    margin-top: 0.6rem;
+    background: var(--accent);
+    box-shadow: 0 0 10px var(--accent);
 }
 
-h2 {
-    font-size: 1.875rem;
-    margin-top: 2rem;
-}
+h2 { font-size: 1.75rem; margin-top: 2rem; }
+h3 { font-size: 1.35rem; }
 
-h3 {
-    font-size: 1.5rem;
-}
+p { margin-bottom: 1.2rem; color: var(--text-soft); }
 
-p {
-    margin-bottom: 1.25rem;
-    color: var(--text-light);
-}
+code, pre, kbd, samp { font-family: var(--font-mono); }
 
-/* Header styles */
+/* selection */
+::selection { background: rgba(0, 255, 136, 0.25); color: #fff; }
+
+/* scrollbar */
+::-webkit-scrollbar { width: 11px; height: 11px; }
+::-webkit-scrollbar-track { background: var(--surface); }
+::-webkit-scrollbar-thumb { background: #25254a; border-radius: 6px; }
+::-webkit-scrollbar-thumb:hover { background: #32325f; }
+
+/* ----------------------------------------------------------------- Header */
 .site-header {
-    background-color: rgba(255, 255, 255, 0.92);
-    backdrop-filter: blur(10px);
-    box-shadow: 0 1px 0 rgba(15, 23, 42, 0.06);
-    border-bottom: 1px solid #e2e8f0;
-    padding: 1rem 0;
+    background: rgba(10, 10, 15, 0.82);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border);
+    padding: 0.9rem 0;
     position: sticky;
     top: 0;
     z-index: 100;
 }
-
 .site-header .container {
     display: flex;
     justify-content: space-between;
     align-items: center;
 }
-
 .logo a {
     display: flex;
     align-items: center;
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: var(--primary-color);
+    font-family: var(--font-display);
+    font-size: 1.6rem;
+    letter-spacing: 3px;
+    font-weight: 400;
+    color: var(--accent);
     text-decoration: none;
+    text-shadow: 0 0 18px rgba(0, 255, 136, 0.4);
+}
+.logo img { height: 38px; margin-right: 12px; }
+
+.text-logo {
+    font-family: var(--font-display);
+    font-size: 1.6rem;
+    letter-spacing: 3px;
+    font-weight: 400;
+    color: var(--accent);
+    text-shadow: 0 0 18px rgba(0, 255, 136, 0.4);
 }
 
-.logo img {
-    height: 40px;
-    margin-right: 12px;
-}
-
-.main-nav ul {
-    display: flex;
-    list-style: none;
-    gap: 1.5rem;
-}
-
+.main-nav ul { display: flex; list-style: none; gap: 0.4rem; }
 .main-nav a {
     text-decoration: none;
-    color: var(--text-color);
+    color: var(--text-soft);
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    letter-spacing: 1px;
+    text-transform: uppercase;
     font-weight: 500;
-    padding: 0.5rem 0.75rem;
+    padding: 0.5rem 0.85rem;
+    border: 1px solid transparent;
     border-radius: var(--border-radius);
-    transition: background-color 0.2s ease, color 0.2s ease;
+    transition: all 0.18s ease;
 }
-
 .main-nav a:hover {
-    background-color: #e0f2fe;
-    color: var(--primary-color);
+    color: var(--accent);
+    border-color: var(--border);
+    background: var(--highlight);
 }
-
 .main-nav a.active {
-    color: var(--primary-color);
-    background-color: #dbeafe;
-    font-weight: 600;
+    color: var(--accent);
+    border-color: rgba(0, 255, 136, 0.4);
+    background: var(--highlight);
 }
 
-/* Main content */
-.site-content {
-    padding: 2rem 0;
-}
+/* --------------------------------------------------------------- Content */
+.site-content { padding: 2.5rem 0 3rem; }
 
-/* Hero section */
+/* ----------------------------------------------------------------- Hero (legacy) */
 .hero {
-    background: linear-gradient(to right, var(--primary-color), var(--secondary-color));
-    color: white;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-top: 3px solid var(--accent);
+    color: var(--text);
     text-align: center;
     padding: 4rem 2rem;
     border-radius: var(--border-radius);
     margin-bottom: 2rem;
     box-shadow: var(--shadow);
 }
-
-.hero h1 {
-    font-size: 2.5rem;
-    margin-bottom: 1rem;
-    border-bottom: none;
-    color: white;
-}
-
+.hero h1 { border-bottom: none; color: var(--text); }
+.hero h1::after { margin-left: auto; margin-right: auto; }
 .subtitle {
-    font-size: 1.25rem;
+    font-size: 1.2rem;
     max-width: 800px;
     margin: 0 auto 2rem;
-    color: rgba(255, 255, 255, 0.9);
+    color: var(--text-soft);
 }
 
 .stats-overview {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 2rem;
-    margin-bottom: 2rem;
+    display: flex; flex-wrap: wrap; justify-content: center;
+    gap: 1.5rem; margin-bottom: 2rem;
 }
-
 .stat-card {
-    background-color: rgba(255, 255, 255, 0.1);
-    backdrop-filter: blur(5px);
-    padding: 1.5rem;
-    border-radius: var(--border-radius);
-    min-width: 180px;
-    transition: transform 0.3s ease;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    padding: 1.5rem; border-radius: var(--border-radius);
+    min-width: 180px; transition: transform 0.25s ease, border-color 0.25s ease;
 }
+.stat-card:hover { transform: translateY(-4px); border-color: var(--accent); }
+.stat-number { font-family: var(--font-display); font-size: 2.6rem; letter-spacing: 2px; color: var(--accent); margin-bottom: 0.4rem; }
+.stat-label { font-family: var(--font-mono); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 2px; color: var(--muted); }
 
-.stat-card:hover {
-    transform: translateY(-5px);
-}
+.cta-buttons { display: flex; justify-content: center; gap: 1rem; flex-wrap: wrap; }
 
-.stat-number {
-    font-size: 2.5rem;
-    font-weight: 700;
-    margin-bottom: 0.5rem;
-}
-
-.stat-label {
-    font-size: 0.875rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-}
-
-.cta-buttons {
-    display: flex;
-    justify-content: center;
-    gap: 1rem;
-    flex-wrap: wrap;
-}
-
-/* Buttons */
+/* ----------------------------------------------------------------- Buttons */
 .btn {
     display: inline-block;
-    background-color: var(--primary-color);
-    color: white;
-    padding: 0.75rem 1.5rem;
+    background: var(--surface-2);
+    color: var(--text);
+    padding: 0.7rem 1.4rem;
+    border: 1px solid var(--border);
     border-radius: var(--border-radius);
     text-decoration: none;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    letter-spacing: 1px;
     font-weight: 600;
-    transition: background-color 0.2s ease, transform 0.2s ease;
-    box-shadow: var(--shadow-sm);
+    transition: all 0.18s ease;
+    cursor: pointer;
 }
-
 .btn:hover {
-    background-color: var(--secondary-color);
-    color: white;
+    color: var(--accent);
+    border-color: var(--accent);
+    background: var(--highlight);
     transform: translateY(-2px);
-    box-shadow: var(--shadow);
 }
-
 .btn.primary {
-    background-color: white;
-    color: var(--primary-color);
+    background: var(--accent);
+    color: #05140d;
+    border-color: var(--accent);
+    box-shadow: 0 0 22px rgba(0, 255, 136, 0.25);
 }
+.btn.primary:hover { background: var(--accent-dim); color: #05140d; }
+.btn.secondary { background: var(--surface-2); color: var(--text-soft); }
+.btn.secondary:hover { color: var(--accent3); border-color: var(--accent3); }
+.btn.small, .btn-small { padding: 0.4rem 0.9rem; font-size: 0.78rem; }
+.btn.outline, .btn-outline { background: transparent; border: 1px solid var(--accent); color: var(--accent); }
+.btn.outline:hover, .btn-outline:hover { background: var(--accent); color: #05140d; }
 
-.btn.primary:hover {
-    background-color: rgba(255, 255, 255, 0.9);
-    color: var(--secondary-color);
-}
-
-.btn.secondary {
-    background-color: rgba(14, 116, 144, 0.1);
-    color: white;
-    border: 1px solid rgba(14, 116, 144, 0.4);
-}
-
-.btn.secondary:hover {
-    background-color: rgba(14, 116, 144, 0.18);
-}
-
-.btn.small {
-    padding: 0.5rem 1rem;
-    font-size: 0.875rem;
-}
-
-.btn.outline {
-    background-color: transparent;
-    border: 1px solid var(--primary-color);
-    color: var(--primary-color);
-}
-
-.btn.outline:hover {
-    background-color: var(--primary-color);
-    color: white;
-}
-
-.btn-outline {
-    background-color: transparent;
-    border: 1px solid var(--primary-color);
-    color: var(--primary-color);
-}
-
-.btn-outline:hover {
-    background-color: var(--primary-color);
-    color: white;
-}
-
-/* Sections */
-.latest-findings, .about-project {
-    background-color: white;
+/* ----------------------------------------------------------- Generic cards */
+.latest-findings, .about-project, .technical-analysis {
+    background: var(--surface);
+    border: 1px solid var(--border);
     padding: 2rem;
     border-radius: var(--border-radius);
     margin-bottom: 2rem;
@@ -282,615 +291,238 @@ p {
 }
 
 .report-summary {
-    border-left: 4px solid var(--primary-color);
+    border-left: 3px solid var(--accent);
     padding: 1.5rem;
-    background-color: rgba(37, 99, 235, 0.05);
+    background: var(--highlight);
     border-radius: 0 var(--border-radius) var(--border-radius) 0;
-}
-
-.mini-stats {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 2rem;
-    margin: 1.5rem 0;
-}
-
-.mini-stat {
-    flex: 1;
-    min-width: 200px;
-}
-
-.mini-stat .label {
-    display: block;
-    margin-bottom: 0.5rem;
-    color: var(--text-light);
-}
-
-.mini-stat .value {
-    font-size: 1.75rem;
-    font-weight: 700;
-    color: var(--primary-color);
-}
-
-.alert {
-    padding: 1rem;
-    border-radius: var(--border-radius);
-    margin-bottom: 1.5rem;
-}
-
-.alert.warning {
-    background-color: rgba(245, 158, 11, 0.1);
-    border-left: 4px solid var(--warning-color);
-    color: #92400e;
-}
-
-/* Report page styles */
-.page-header {
     margin-bottom: 2rem;
 }
 
-.report-actions {
-    display: flex;
-    gap: 1rem;
-    margin-top: 1rem;
-}
+.mini-stats { display: flex; flex-wrap: wrap; gap: 2rem; margin: 1.5rem 0; }
+.mini-stat { flex: 1; min-width: 200px; }
+.mini-stat .label { display: block; margin-bottom: 0.5rem; color: var(--muted); font-family: var(--font-mono); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 1px; }
+.mini-stat .value { font-family: var(--font-display); font-size: 1.9rem; letter-spacing: 1px; color: var(--accent); }
 
-.report-summary {
-    margin-bottom: 2rem;
-}
+.alert { padding: 1rem 1.25rem; border-radius: var(--border-radius); margin-bottom: 1.5rem; border: 1px solid var(--border); }
+.alert.warning { background: rgba(255, 204, 0, 0.08); border-left: 3px solid var(--warning-color); color: #ffe08a; }
 
-.summary-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1.5rem;
-}
+/* -------------------------------------------------------- Report summary grid */
+.page-header { margin-bottom: 2rem; }
+.report-actions { display: flex; gap: 1rem; margin-top: 1rem; flex-wrap: wrap; }
 
+.summary-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1.25rem; }
 .summary-card {
-    background-color: white;
-    padding: 1.5rem;
-    border-radius: var(--border-radius);
-    box-shadow: var(--shadow);
-    text-align: center;
-    transition: transform 0.3s ease;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 1.5rem; border-radius: var(--border-radius);
+    box-shadow: var(--shadow); text-align: center;
+    transition: transform 0.25s ease, border-color 0.25s ease;
 }
+.summary-card:hover { transform: translateY(-4px); border-color: var(--accent); }
+.summary-card h3 { font-family: var(--font-display); font-size: 2.6rem; letter-spacing: 1px; color: var(--accent); margin-bottom: 0.4rem; }
 
-.summary-card:hover {
-    transform: translateY(-5px);
-}
-
-.summary-card h3 {
-    font-size: 2.5rem;
-    color: var(--primary-color);
-    margin-bottom: 0.5rem;
-}
-
-/* Attack breakdown */
-.attack-breakdown {
-    margin-bottom: 2rem;
-}
-
-.breakdown-cards {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 1.5rem;
-}
-
+/* ------------------------------------------------------------ Attack breakdown */
+.attack-breakdown { margin-bottom: 2rem; }
+.breakdown-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.25rem; }
 .breakdown-card {
-    background-color: white;
-    padding: 1.5rem;
-    border-radius: var(--border-radius);
-    box-shadow: var(--shadow);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 1.5rem; border-radius: var(--border-radius); box-shadow: var(--shadow);
 }
+.stat-value { font-family: var(--font-display); font-size: 2.1rem; letter-spacing: 1px; color: var(--accent); margin-bottom: 0.5rem; }
 
-.stat-value {
-    font-size: 2rem;
-    font-weight: 700;
-    color: var(--primary-color);
-    margin-bottom: 0.5rem;
-}
+.progress-bar { height: 8px; background: var(--surface-3); border-radius: 999px; overflow: hidden; margin-bottom: 0.5rem; }
+.progress { height: 100%; background: linear-gradient(90deg, var(--accent-dim), var(--accent)); transition: width 1s ease-in-out; }
 
-.progress-bar {
-    height: 10px;
-    background-color: #e9ecef;
-    border-radius: 1rem;
-    overflow: hidden;
-    margin-bottom: 0.5rem;
-}
-
-.progress {
-    height: 100%;
-    background-color: var(--primary-color);
-    transition: width 1s ease-in-out;
-}
-
-/* Affected sites */
-.sites-list {
-    margin-bottom: 2rem;
-}
-
+/* ------------------------------------------------------------- Tables */
+.sites-list { margin-bottom: 2rem; }
 .sites-table-wrapper {
     overflow-x: auto;
-    background-color: white;
+    background: var(--surface);
+    border: 1px solid var(--border);
     border-radius: var(--border-radius);
     box-shadow: var(--shadow);
 }
-
-.sites-table {
-    width: 100%;
-    border-collapse: collapse;
-}
-
-.sites-table th,
-.sites-table td {
-    padding: 1rem;
-    text-align: left;
-    border-bottom: 1px solid #e5e7eb;
-}
-
+.sites-table { width: 100%; border-collapse: collapse; font-size: 0.92rem; }
+.sites-table th, .sites-table td { padding: 0.9rem 1rem; text-align: left; border-bottom: 1px solid var(--border); }
 .sites-table th {
-    background-color: #f9fafb;
-    font-weight: 600;
+    background: var(--surface-2);
+    font-family: var(--font-mono);
+    font-size: 0.74rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--accent);
+    border-bottom: 2px solid var(--accent);
 }
+.sites-table tr:last-child td { border-bottom: none; }
+.sites-table tbody tr { transition: background 0.15s ease; }
+.sites-table tbody tr:hover { background: var(--highlight); }
 
-.sites-table tr:last-child td {
-    border-bottom: none;
-}
-
-.sites-table tr:hover {
-    background-color: #f9fafb;
-}
-
-/* Technical analysis */
-.technical-analysis {
-    background-color: white;
-    padding: 2rem;
-    border-radius: var(--border-radius);
-    box-shadow: var(--shadow);
-}
-
-.analysis-content {
-    line-height: 1.7;
-}
-
-.analysis-content h2 {
-    margin-top: 2rem;
-    margin-bottom: 1rem;
-    font-size: 1.5rem;
-}
-
-.analysis-content ul,
-.analysis-content ol {
-    margin-left: 1.5rem;
-    margin-bottom: 1.5rem;
-}
-
-.analysis-content p {
-    margin-bottom: 1.25rem;
-}
-
+/* ------------------------------------------------------ Analysis prose */
+.analysis-content { line-height: 1.75; }
+.analysis-content h2 { margin-top: 2rem; margin-bottom: 1rem; font-size: 1.5rem; color: var(--text); }
+.analysis-content ul, .analysis-content ol { margin-left: 1.5rem; margin-bottom: 1.5rem; }
+.analysis-content p { margin-bottom: 1.2rem; }
 .analysis-content pre {
-    background-color: #f9fafb;
-    padding: 1.25rem;
-    border-radius: var(--border-radius);
-    overflow-x: auto;
-    margin-bottom: 1.25rem;
-    border: 1px solid #e5e7eb;
+    background: #05050a;
+    padding: 1.2rem; border-radius: var(--border-radius);
+    overflow-x: auto; margin-bottom: 1.2rem;
+    border: 1px solid var(--border); border-left: 3px solid var(--accent);
+    font-size: 0.86rem; line-height: 1.6;
 }
-
-.analysis-content code {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-    background-color: #f9fafb;
-    padding: 0.125rem 0.25rem;
-    border-radius: 0.25rem;
-    font-size: 0.875em;
-    border: 1px solid #e5e7eb;
+.analysis-content code, code {
+    font-family: var(--font-mono);
+    background: var(--surface-3);
+    padding: 0.12rem 0.4rem; border-radius: 4px;
+    font-size: 0.86em; color: var(--accent3);
+    border: 1px solid var(--border);
 }
+.analysis-content pre code { background: none; border: none; padding: 0; color: var(--text-soft); }
 
-/* Reports list page */
+/* ---------------------------------------------------- Reports list page */
 .report-filter {
-    background-color: white;
-    padding: 1.5rem;
-    border-radius: var(--border-radius);
-    margin-bottom: 2rem;
-    box-shadow: var(--shadow);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 1.5rem; border-radius: var(--border-radius);
+    margin-bottom: 2rem; box-shadow: var(--shadow);
 }
-
-.filter-controls {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1.5rem;
-}
-
-.filter-group {
-    flex: 1;
-    min-width: 200px;
-}
-
+.filter-controls { display: flex; flex-wrap: wrap; gap: 1.5rem; }
+.filter-group { flex: 1; min-width: 200px; }
 .filter-select {
-    width: 100%;
-    padding: 0.75rem;
+    width: 100%; padding: 0.7rem;
     border-radius: var(--border-radius);
-    border: 1px solid #e5e7eb;
-    background-color: white;
-    font-size: 1rem;
-    margin-top: 0.5rem;
+    border: 1px solid var(--border);
+    background: var(--surface-2); color: var(--text);
+    font-family: var(--font-mono); font-size: 0.9rem; margin-top: 0.5rem;
 }
+.year-group { margin-bottom: 3rem; }
+.month-group { margin-bottom: 2rem; }
 
-.year-group {
-    margin-bottom: 3rem;
-}
-
-.month-group {
-    margin-bottom: 2rem;
-}
-
-.reports-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    gap: 1.5rem;
-    margin-top: 1rem;
-}
-
+.reports-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.25rem; margin-top: 1rem; }
 .report-card {
-    background-color: white;
+    background: var(--surface);
+    border: 1px solid var(--border);
     border-radius: var(--border-radius);
-    padding: 1.5rem;
-    box-shadow: var(--shadow);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    padding: 1.5rem; box-shadow: var(--shadow);
+    transition: transform 0.25s ease, border-color 0.25s ease;
 }
+.report-card:hover { transform: translateY(-4px); border-color: var(--accent); box-shadow: var(--shadow-lg); }
+.report-date { color: var(--muted); font-family: var(--font-mono); font-size: 0.8rem; margin-bottom: 0.5rem; }
+.report-card h4 { font-size: 1.2rem; margin-bottom: 1rem; color: var(--text); }
+.report-stats { display: flex; gap: 1.5rem; margin-bottom: 1.5rem; }
+.report-stats .stat { flex: 1; }
+.report-stats .value { display: block; font-family: var(--font-display); font-size: 1.5rem; letter-spacing: 1px; color: var(--accent); margin-bottom: 0.25rem; }
+.report-stats .label { font-family: var(--font-mono); font-size: 0.7rem; text-transform: uppercase; letter-spacing: 1px; color: var(--muted); }
 
-.report-card:hover {
-    transform: translateY(-5px);
-    box-shadow: var(--shadow-lg);
-}
-
-.report-date {
-    color: var(--text-light);
-    font-size: 0.875rem;
-    margin-bottom: 0.5rem;
-}
-
-.report-card h4 {
-    font-size: 1.25rem;
-    margin-bottom: 1rem;
-}
-
-.report-stats {
-    display: flex;
-    gap: 1.5rem;
-    margin-bottom: 1.5rem;
-}
-
-.report-stats .stat {
-    flex: 1;
-}
-
-.report-stats .value {
-    display: block;
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: var(--primary-color);
-    margin-bottom: 0.25rem;
-}
-
-.report-stats .label {
-    font-size: 0.75rem;
-    color: var(--text-light);
-}
-
-.new-patterns {
-    margin-bottom: 1.5rem;
-    padding: 0.5rem 0.75rem;
-    background-color: rgba(245, 158, 11, 0.1);
-    border-radius: var(--border-radius);
-    font-size: 0.875rem;
-}
-
+.new-patterns { margin-bottom: 1.5rem; padding: 0.5rem 0.75rem; background: rgba(255, 204, 0, 0.08); border: 1px solid rgba(255, 204, 0, 0.25); border-radius: var(--border-radius); font-size: 0.85rem; }
 .badge {
-    display: inline-block;
-    background-color: var(--warning-color);
-    color: white;
-    padding: 0.125rem 0.375rem;
-    border-radius: 0.25rem;
-    font-weight: 600;
-    font-size: 0.75rem;
-    margin-right: 0.375rem;
+    display: inline-block; background: var(--accent4); color: #1a1500;
+    padding: 0.12rem 0.45rem; border-radius: 4px; font-weight: 700;
+    font-family: var(--font-mono); font-size: 0.7rem; margin-right: 0.375rem;
 }
 
 .view-report {
-    display: block;
-    text-align: center;
-    background-color: #f9fafb;
-    padding: 0.75rem;
-    border-radius: var(--border-radius);
-    font-weight: 500;
-    transition: background-color 0.2s;
+    display: block; text-align: center;
+    background: var(--surface-2); border: 1px solid var(--border);
+    padding: 0.7rem; border-radius: var(--border-radius);
+    font-family: var(--font-mono); font-size: 0.82rem; letter-spacing: 1px;
+    color: var(--accent); transition: all 0.18s;
 }
+.view-report:hover { background: var(--highlight); border-color: var(--accent); }
 
-.view-report:hover {
-    background-color: var(--primary-color);
-    color: white;
-}
-
-.pagination {
-    text-align: center;
-    margin-top: 3rem;
-}
-
+.pagination { text-align: center; margin-top: 3rem; }
 .pagination-btn {
-    background-color: white;
-    border: 1px solid #e5e7eb;
-    padding: 0.75rem 1.5rem;
-    border-radius: var(--border-radius);
-    font-size: 1rem;
-    cursor: pointer;
-    transition: background-color 0.2s, border-color 0.2s;
-    box-shadow: var(--shadow-sm);
+    background: var(--surface-2); border: 1px solid var(--border);
+    padding: 0.7rem 1.4rem; border-radius: var(--border-radius);
+    font-family: var(--font-mono); font-size: 0.9rem; color: var(--text);
+    cursor: pointer; transition: all 0.18s;
 }
+.pagination-btn:hover { border-color: var(--accent); color: var(--accent); }
 
-.pagination-btn:hover {
-    background-color: #f9fafb;
-    border-color: #d1d5db;
-}
-
-/* Footer styles */
+/* ---------------------------------------------------------------- Footer */
 .site-footer {
-    background-color: #0f172a;
-    color: white;
-    padding: 3rem 0;
-    margin-top: 3rem;
+    background: #06060a;
+    border-top: 1px solid var(--border);
+    color: var(--text-soft);
+    padding: 3rem 0 2rem;
+    margin-top: 4rem;
+    position: relative;
 }
-
-.footer-content {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 3rem;
+.site-footer::before {
+    content: '';
+    position: absolute; top: -1px; left: 0; right: 0; height: 1px;
+    background: linear-gradient(90deg, transparent, var(--accent), transparent);
+    opacity: 0.5;
 }
+.footer-content { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 3rem; }
+.footer-logo img { height: 38px; margin-bottom: 1rem; }
+.footer-logo p { color: var(--muted); font-size: 0.85rem; }
+.footer-links h3 { color: var(--text); margin-bottom: 1.1rem; font-family: var(--font-mono); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 2px; }
+.footer-links ul { list-style: none; }
+.footer-links li { margin-bottom: 0.7rem; }
+.footer-links a { color: var(--muted); font-size: 0.86rem; }
+.footer-links a:hover { color: var(--accent); }
+.footer-bottom { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--border); text-align: center; font-size: 0.82rem; color: var(--muted); }
 
-.footer-logo img {
-    height: 40px;
-    margin-bottom: 1rem;
-}
-
-.footer-logo p {
-    color: #9ca3af;
-    font-size: 0.875rem;
-}
-
-.footer-links h3 {
-    color: white;
-    margin-bottom: 1.25rem;
-    font-size: 1rem;
-}
-
-.footer-links ul {
-    list-style: none;
-}
-
-.footer-links li {
-    margin-bottom: 0.75rem;
-}
-
-.footer-links a {
-    color: #9ca3af;
-    text-decoration: none;
-    transition: color 0.2s ease;
-    font-size: 0.875rem;
-}
-
-.footer-links a:hover {
-    color: white;
-}
-
-.footer-bottom {
-    margin-top: 3rem;
-    padding-top: 1.5rem;
-    border-top: 1px solid #374151;
-    text-align: center;
-    font-size: 0.875rem;
-    color: #9ca3af;
-}
-
-/* Responsive styles */
-@media (max-width: 768px) {
-    .site-header .container {
-        flex-direction: column;
-    }
-    
-    .main-nav ul {
-        margin-top: 1rem;
-        justify-content: center;
-    }
-    
-    .hero h1 {
-        font-size: 1.875rem;
-    }
-    
-    .stat-card {
-        width: 100%;
-    }
-    
-    .footer-content {
-        grid-template-columns: 1fr;
-    }
-
-    .stats-overview {
-        flex-direction: column;
-        align-items: center;
-    }
-
-    .stat-card {
-        width: 80%;
-    }
-}
-
-/* Add styles for the detailed URL analysis section */
-.detailed-findings {
-  margin-top: 3rem;
-}
-
+/* ----------------------------------------------------- Detailed URL cards */
+.detailed-findings { margin-top: 3rem; }
 .url-analysis-card {
-  background-color: #fff;
-  border-radius: 8px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-  margin-bottom: 2rem;
-  overflow: hidden;
-  transition: box-shadow 0.3s ease;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius);
+    box-shadow: var(--shadow);
+    margin-bottom: 2rem; overflow: hidden;
+    transition: box-shadow 0.25s ease, border-color 0.25s ease;
 }
+.url-analysis-card.highlight { border-color: var(--accent4); box-shadow: 0 0 22px rgba(255, 204, 0, 0.25); }
+.url-header { background: var(--surface-2); padding: 1.4rem; border-bottom: 1px solid var(--border); }
+.url-header h3 { margin: 0 0 0.5rem 0; color: var(--text); word-break: break-all; }
+.url-meta { display: flex; gap: 1.5rem; font-family: var(--font-mono); font-size: 0.82rem; color: var(--muted); flex-wrap: wrap; }
+.url-type { background: rgba(61, 158, 255, 0.12); color: var(--accent3); border: 1px solid rgba(61, 158, 255, 0.3); border-radius: 4px; padding: 0.2rem 0.7rem; font-weight: 600; }
+.url-findings strong { color: var(--accent2); }
 
-.url-analysis-card.highlight {
-  box-shadow: 0 0 15px rgba(255, 165, 0, 0.7);
-}
-
-.url-header {
-  background-color: #f5f7fa;
-  padding: 1.5rem;
-  border-bottom: 1px solid #eaeef3;
-}
-
-.url-header h3 {
-  margin: 0 0 0.5rem 0;
-  color: #2c3e50;
-}
-
-.url-meta {
-  display: flex;
-  gap: 1.5rem;
-  font-size: 0.9rem;
-  color: #6c757d;
-}
-
-.url-type {
-  background-color: #e1f5fe;
-  color: #0277bd;
-  border-radius: 4px;
-  padding: 0.25rem 0.75rem;
-  font-weight: 500;
-}
-
-.url-findings strong {
-  color: #e74c3c;
-}
-
-.url-tabs {
-  display: flex;
-  background-color: #f8f9fa;
-  border-bottom: 1px solid #eaeef3;
-  padding: 0 1rem;
-}
-
+.url-tabs { display: flex; background: var(--surface-2); border-bottom: 1px solid var(--border); padding: 0 1rem; flex-wrap: wrap; }
 .tab-btn {
-  background: none;
-  border: none;
-  padding: 1rem 1.25rem;
-  cursor: pointer;
-  color: #6c757d;
-  font-weight: 500;
-  border-bottom: 2px solid transparent;
-  transition: all 0.2s ease;
+    background: none; border: none; padding: 0.9rem 1.2rem; cursor: pointer;
+    color: var(--muted); font-family: var(--font-mono); font-size: 0.82rem; font-weight: 500;
+    border-bottom: 2px solid transparent; transition: all 0.18s ease;
 }
+.tab-btn:hover { color: var(--accent3); }
+.tab-btn.active { color: var(--accent); border-bottom-color: var(--accent); }
+.tab-content { display: none; padding: 1.5rem; }
+.tab-content.active { display: block; }
 
-.tab-btn:hover {
-  color: #3498db;
+.code-block { background: #05050a; border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: var(--border-radius); overflow: hidden; margin-bottom: 1.5rem; }
+.code-block pre { margin: 0; padding: 1.2rem; font-family: var(--font-mono); font-size: 0.86rem; line-height: 1.6; overflow-x: auto; }
+.code-block code { background: none; padding: 0; color: var(--text-soft); border: none; }
+
+.findings-groups { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.25rem; }
+.findings-group { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius); padding: 1.2rem; }
+.findings-group h4 { margin-top: 0; margin-bottom: 1rem; color: var(--text); font-family: var(--font-mono); font-size: 0.92rem; text-transform: uppercase; letter-spacing: 1px; }
+.findings-group ul { margin: 0; padding: 0; list-style: none; }
+.findings-group li { margin-bottom: 0.75rem; }
+.findings-group code { background: var(--surface-3); padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.82rem; color: var(--accent3); border: 1px solid var(--border); word-break: break-all; display: inline-block; max-width: 100%; }
+
+.malicious-url { color: var(--accent2); text-decoration: none; word-break: break-all; }
+.malicious-url:hover { text-decoration: underline; }
+
+/* ------------------------------------------------------------ Utilities */
+.mono { font-family: var(--font-mono); }
+.glow-green { text-shadow: 0 0 18px rgba(0, 255, 136, 0.5); }
+.text-accent { color: var(--accent); }
+.text-red { color: var(--accent2); }
+.text-blue { color: var(--accent3); }
+.text-gold { color: var(--accent4); }
+
+@keyframes blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
+.cursor::after { content: '_'; animation: blink 1s step-end infinite; color: var(--accent); }
+
+/* ----------------------------------------------------------- Responsive */
+@media (max-width: 768px) {
+    .site-header .container { flex-direction: column; gap: 0.8rem; }
+    .main-nav ul { flex-wrap: wrap; justify-content: center; }
+    .footer-content { grid-template-columns: 1fr; }
+    .stats-overview { flex-direction: column; align-items: center; }
+    .stat-card { width: 100%; }
+    .report-stats { flex-wrap: wrap; }
 }
-
-.tab-btn.active {
-  color: #2c3e50;
-  border-bottom-color: #3498db;
-}
-
-.tab-content {
-  display: none;
-  padding: 1.5rem;
-}
-
-.tab-content.active {
-  display: block;
-}
-
-.code-block {
-  background-color: #f8f9fb;
-  border-radius: 6px;
-  overflow: hidden;
-  margin-bottom: 1.5rem;
-}
-
-.code-block pre {
-  margin: 0;
-  padding: 1.25rem;
-  font-family: 'Monaco', 'Consolas', monospace;
-  font-size: 0.9rem;
-  line-height: 1.5;
-  overflow-x: auto;
-}
-
-.code-block code {
-  background: none;
-  padding: 0;
-  color: #333;
-}
-
-.findings-groups {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 1.5rem;
-}
-
-.findings-group {
-  background-color: #f8f9fb;
-  border-radius: 6px;
-  padding: 1.25rem;
-}
-
-.findings-group h4 {
-  margin-top: 0;
-  margin-bottom: 1rem;
-  color: #2c3e50;
-  font-size: 1rem;
-}
-
-.findings-group ul {
-  margin: 0;
-  padding: 0;
-  list-style-type: none;
-}
-
-.findings-group li {
-  margin-bottom: 0.75rem;
-}
-
-.findings-group code {
-  background-color: #f1f3f5;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  font-size: 0.85rem;
-  word-break: break-all;
-  display: inline-block;
-  max-width: 100%;
-  overflow-x: auto;
-}
-
-.malicious-url {
-  color: #e74c3c;
-  text-decoration: none;
-  word-break: break-all;
-}
-
-.malicious-url:hover {
-  text-decoration: underline;
-}
-
-.btn-small {
-  display: inline-block;
-  padding: 0.25rem 0.75rem;
-  font-size: 0.85rem;
-  background-color: #3498db;
-  color: white;
-  border-radius: 4px;
-  text-decoration: none;
-  transition: background-color 0.2s ease;
-}
-
-.btn-small:hover {
-  background-color: #2980b9;
-} 

--- a/public/examples/colorcpl.exe-your-monitor-display-profile-is-corrupt.html
+++ b/public/examples/colorcpl.exe-your-monitor-display-profile-is-corrupt.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Your Monitor Display Profile is Corrupt - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/public/examples/colorcpl.exe-your-monitor-is-displaying-colors-incorrectly.html
+++ b/public/examples/colorcpl.exe-your-monitor-is-displaying-colors-incorrectly.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Your Monitor is Displaying Colors Incorrectly - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/public/examples/consentfix-consentfix-oauth-token-theft.html
+++ b/public/examples/consentfix-consentfix-oauth-token-theft.html
@@ -1,0 +1,362 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>ConsentFix OAuth Token Theft - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
+        body {
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
+            margin: 0;
+            padding: 0;
+        }
+        .center-box {
+            position: fixed;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
+            padding: 32px 24px 24px 24px;
+            text-align: center;
+            min-width: 300px;
+            max-width: 500px;
+        }
+        .example-title {
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
+            margin-bottom: 10px;
+            color: var(--accent);
+        }
+        .example-desc {
+            color: var(--text-soft);
+            font-size: 13px;
+            margin-top: 10px;
+            line-height: 1.4;
+        }
+        .step-container {
+            margin: 20px 0;
+            text-align: left;
+        }
+        .step {
+            position: relative;
+            padding: 16px 16px 16px 52px;
+            margin: 10px 0;
+            font-size: 14px;
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
+        }
+        .step-number {
+            position: absolute;
+            left: 14px;
+            top: 50%;
+            transform: translateY(-50%);
+            width: 28px;
+            height: 28px;
+            border-radius: 50%;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 800;
+            font-size: 14px;
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
+        }
+        .step-content {
+            display: inline;
+        }
+        /* Keycap-style emphasis for shortcuts and important words */
+        .step-content strong {
+            color: var(--accent);
+            font-family: var(--font-mono);
+            font-weight: 700;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
+            padding: 1px 6px;
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
+        }
+        .step-content code {
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
+            padding: 1px 6px;
+            border-radius: var(--border-radius);
+        }
+        .action-btn {
+            background: var(--accent);
+            color: var(--bg);
+            border: none;
+            border-radius: var(--border-radius);
+            padding: 12px 32px;
+            font-family: var(--font-mono);
+            font-size: 16px;
+            font-weight: 700;
+            letter-spacing: 0.5px;
+            cursor: pointer;
+            margin-top: 18px;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
+        }
+        .action-btn:active {
+            background: var(--accent-dim);
+        }
+        .action-btn:disabled {
+            background: var(--muted);
+            color: var(--surface);
+            cursor: not-allowed;
+        }
+        .copied-msg {
+            color: var(--accent);
+            font-family: var(--font-mono);
+            margin-top: 16px;
+            font-size: 14px;
+            display: none;
+        }
+        .warning-msg {
+            color: var(--accent2);
+            font-family: var(--font-mono);
+            margin-top: 16px;
+            font-size: 14px;
+            display: none;
+        }
+        .progress-bar {
+            width: 100%;
+            height: 4px;
+            background: var(--surface-3);
+            border-radius: 2px;
+            margin: 16px 0;
+            overflow: hidden;
+        }
+        .progress-fill {
+            height: 100%;
+            background: var(--accent);
+            width: 0%;
+            transition: width 0.3s ease;
+        }
+        .step-highlight {
+            background: var(--highlight);
+            border-color: var(--accent4);
+        }
+        .step-completed {
+            background: var(--surface-3);
+            border-color: var(--accent);
+        }
+        .step-completed .step-number {
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
+        }
+        /* Special treatment for the first step like ClickFix callout */
+        #step-1 {
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
+        }
+        #step-1 .step-number {
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
+        }
+        .back-link {
+            position: absolute;
+            top: 20px;
+            left: 20px;
+            color: var(--accent);
+            font-family: var(--font-mono);
+            text-decoration: none;
+            font-size: 14px;
+            font-weight: 500;
+            transition: color 0.18s ease;
+        }
+        .back-link:hover {
+            color: var(--accent-dim);
+            text-decoration: underline;
+        }
+        .disclaimer {
+            position: absolute;
+            bottom: 20px;
+            left: 50%;
+            transform: translateX(-50%);
+            font-family: var(--font-mono);
+            font-size: 12px;
+            color: var(--muted);
+            text-align: center;
+            max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
+        }
+    </style>
+</head>
+<body>
+    <a href="/ClickGrab/techniques/consentfix.html" class="back-link">← Back to ConsentFix</a>
+    
+    <div class="center-box">
+        <div class="example-title">ConsentFix OAuth Token Theft</div>
+        <div class="example-desc"><p>To complete the verification, please copy the URL from your browser's address bar and paste it in the box below.</p></div>
+        
+        <div class="progress-bar">
+            <div class="progress-fill" id="progressFill"></div>
+        </div>
+        
+        <div class="step-container" id="stepContainer">
+            
+            <div class="step" id="step-1">
+                <span class="step-number">1</span>
+                <span class="step-content"><p>Copy the <strong>URL</strong> from your browser's address bar</p></span>
+            </div>
+            
+            <div class="step" id="step-2">
+                <span class="step-number">2</span>
+                <span class="step-content"><p>Paste it in the <strong>verification box</strong> below</p></span>
+            </div>
+            
+            <div class="step" id="step-3">
+                <span class="step-number">3</span>
+                <span class="step-content"><p>Click <strong>Verify</strong></p></span>
+            </div>
+            
+        </div>
+        
+        <div style="margin: 8px 0;">
+            
+        </div>
+        <button class="action-btn" id="actionBtn">Next Step</button>
+        <div class="copied-msg" id="copiedMsg">Copied to clipboard!</div>
+        <div class="warning-msg" id="warningMsg">⚠️ This is a demonstration - do not run this command!</div>
+    </div>
+    
+    <div class="disclaimer">
+        <strong>Educational Example:</strong> This is a demonstration of what a social engineering attack might look like. 
+        Never run commands from untrusted sources. This example is for educational purposes only.
+    </div>
+    
+    <script>
+        let currentStep = 0;
+        const totalSteps = 3;
+        const steps = ["Copy the **URL** from your browser\u0027s address bar", "Paste it in the **verification box** below", "Click **Verify**"];
+        let textToCopy = "ConsentFix";
+        
+        function updateProgress() {
+            const progress = (currentStep / totalSteps) * 100;
+            document.getElementById('progressFill').style.width = progress + '%';
+        }
+        
+        function highlightCurrentStep() {
+            // Remove previous highlights
+            document.querySelectorAll('.step').forEach(step => {
+                step.classList.remove('step-highlight');
+            });
+            
+            // Highlight current step
+            if (currentStep < totalSteps) {
+                const currentStepEl = document.getElementById('step-' + (currentStep + 1));
+                if (currentStepEl) {
+                    currentStepEl.classList.add('step-highlight');
+                }
+            }
+        }
+        
+        function markStepCompleted(stepIndex) {
+            const stepEl = document.getElementById('step-' + stepIndex);
+            if (stepEl) {
+                stepEl.classList.remove('step-highlight');
+                stepEl.classList.add('step-completed');
+            }
+        }
+        
+        function showCopiedMsg() {
+            const msg = document.getElementById('copiedMsg');
+            msg.style.display = 'block';
+            setTimeout(() => { msg.style.display = 'none'; }, 2000);
+        }
+        
+        function showWarningMsg() {
+            const msg = document.getElementById('warningMsg');
+            msg.style.display = 'block';
+            setTimeout(() => { msg.style.display = 'none'; }, 3000);
+        }
+        
+        function fallbackCopy() {
+            const temp = document.createElement("textarea");
+            temp.value = textToCopy;
+            document.body.appendChild(temp);
+            temp.select();
+            document.execCommand("copy");
+            document.body.removeChild(temp);
+            showCopiedMsg();
+        }
+        
+        function copyToClipboard() {
+            if (navigator.clipboard) {
+                navigator.clipboard.writeText(textToCopy).then(function() {
+                    showCopiedMsg();
+                }, function() {
+                    fallbackCopy();
+                });
+            } else {
+                fallbackCopy();
+            }
+        }
+        
+        
+
+        document.getElementById('actionBtn').addEventListener('click', function() {
+            if (currentStep < totalSteps) {
+                // Mark current step as completed
+                markStepCompleted(currentStep + 1);
+                currentStep++;
+                updateProgress();
+                highlightCurrentStep();
+                
+                // Update button text
+                if (currentStep < totalSteps) {
+                    this.textContent = "Next Step";
+                } else {
+                    this.textContent = "Copy Command";
+                }
+            } else {
+                // Final step - copy command
+                copyToClipboard();
+                showWarningMsg();
+            }
+        });
+        
+        // Initialize
+        updateProgress();
+        highlightCurrentStep();
+    </script>
+</body>
+</html>

--- a/public/examples/dcomcnfg.exe-open-component-services.html
+++ b/public/examples/dcomcnfg.exe-open-component-services.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Open Component Services - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/public/examples/explorer-shell-uris-open-recycle-bin.html
+++ b/public/examples/explorer-shell-uris-open-recycle-bin.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Open Recycle Bin - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/public/examples/explorer-shell-uris-open-startup-folder.html
+++ b/public/examples/explorer-shell-uris-open-startup-folder.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Open Startup folder - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/public/examples/msiexec.exe-quiet-install-from-url-demo.html
+++ b/public/examples/msiexec.exe-quiet-install-from-url-demo.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Quiet install from URL (demo) - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/public/examples/msra.exe-get-remote-support.html
+++ b/public/examples/msra.exe-get-remote-support.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Get Remote Support - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/public/examples/office-uri-open-excel-via-uri-safe-demo.html
+++ b/public/examples/office-uri-open-excel-via-uri-safe-demo.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Open Excel via URI (safe demo) - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/public/examples/powershell.exe-fix-network-configuration.html
+++ b/public/examples/powershell.exe-fix-network-configuration.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Fix Network Configuration - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/public/examples/powershell.exe-fix-windows-security-update.html
+++ b/public/examples/powershell.exe-fix-windows-security-update.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Fix Windows Security Update - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/public/examples/search-ms-open-explorer-search-to-a-folder.html
+++ b/public/examples/search-ms-open-explorer-search-to-a-folder.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Open Explorer search to a folder - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/public/examples/taskmgr.exe-open-file-location-explorer-window.html
+++ b/public/examples/taskmgr.exe-open-file-location-explorer-window.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>Open file location (Explorer window) - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>

--- a/public/index.html
+++ b/public/index.html
@@ -5,482 +5,308 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ClickGrab - Advanced Threat Intelligence for Clipboard Hijacking Attacks</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <style>
+    /* ---- Hero ------------------------------------------------------ */
     .intel-hero {
-        background: linear-gradient(140deg, #082f49 0%, #0f766e 55%, #0891b2 100%);
-        color: #e2f2ff;
-        border-radius: 20px;
-        padding: 3.5rem 2.25rem;
+        background:
+            linear-gradient(135deg, var(--surface) 0%, var(--surface-2) 100%);
+        color: var(--text);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        border-radius: var(--border-radius);
+        padding: 3.25rem 2.25rem;
         margin-bottom: 2.5rem;
-        box-shadow: 0 18px 45px rgba(8, 47, 73, 0.25);
+        box-shadow: var(--shadow);
         position: relative;
         overflow: hidden;
     }
-
+    .intel-hero::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-image:
+            linear-gradient(rgba(0,255,136,0.04) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(0,255,136,0.04) 1px, transparent 1px);
+        background-size: 34px 34px;
+        pointer-events: none;
+    }
     .intel-hero::after {
         content: '';
         position: absolute;
         inset: 0;
         background:
-            radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.14), transparent 36%),
-            radial-gradient(circle at 82% 8%, rgba(207, 250, 254, 0.2), transparent 34%);
+            radial-gradient(circle at 12% 12%, rgba(0, 255, 136, 0.16), transparent 38%),
+            radial-gradient(circle at 88% 4%, rgba(61, 158, 255, 0.16), transparent 36%);
         pointer-events: none;
     }
-
-    .intel-hero-content {
-        position: relative;
-        z-index: 1;
-    }
+    .intel-hero-content { position: relative; z-index: 1; }
 
     .hero-kicker {
         display: inline-flex;
         align-items: center;
         gap: 0.45rem;
-        font-size: 0.82rem;
-        letter-spacing: 0.08em;
+        font-family: var(--font-mono);
+        font-size: 0.74rem;
+        letter-spacing: 0.18em;
         text-transform: uppercase;
-        font-weight: 700;
-        color: #d1fae5;
-        background: rgba(3, 7, 18, 0.28);
-        border: 1px solid rgba(255, 255, 255, 0.2);
-        padding: 0.45rem 0.8rem;
+        font-weight: 600;
+        color: var(--accent);
+        background: var(--highlight);
+        border: 1px solid rgba(0, 255, 136, 0.3);
+        padding: 0.4rem 0.85rem;
         border-radius: 999px;
-        margin-bottom: 1rem;
+        margin-bottom: 1.25rem;
+    }
+    .hero-kicker::before {
+        content: '';
+        width: 7px; height: 7px; border-radius: 50%;
+        background: var(--accent);
+        box-shadow: 0 0 8px var(--accent);
+        animation: blink 1.6s ease-in-out infinite;
     }
 
     .hero-title {
-        font-size: clamp(2rem, 4vw, 3rem);
-        margin-bottom: 0.85rem;
-        line-height: 1.15;
+        font-family: var(--font-display);
+        font-weight: 400;
+        font-size: clamp(2.4rem, 5vw, 3.8rem);
+        letter-spacing: 2px;
+        line-height: 1.04;
+        margin-bottom: 0.95rem;
         border-bottom: none;
-        color: #f8fafc;
+        background: linear-gradient(135deg, var(--accent) 0%, var(--accent-dim) 45%, var(--accent3) 100%);
+        -webkit-background-clip: text;
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
     }
+    .hero-title::after { display: none; }
 
     .hero-subtitle {
-        color: rgba(248, 250, 252, 0.92);
+        color: var(--text-soft);
         max-width: 900px;
-        font-size: 1.12rem;
-        margin-bottom: 1.6rem;
+        font-size: 1.08rem;
+        margin-bottom: 1.5rem;
     }
 
     .trend-chip {
         display: inline-flex;
         align-items: center;
-        gap: 0.45rem;
+        gap: 0.5rem;
+        font-family: var(--font-mono);
         border-radius: 999px;
-        font-size: 0.9rem;
-        font-weight: 600;
-        padding: 0.45rem 0.9rem;
+        font-size: 0.82rem;
+        font-weight: 500;
+        padding: 0.4rem 0.9rem;
         margin-bottom: 2rem;
-        border: 1px solid transparent;
+        border: 1px solid var(--border);
+        background: var(--surface-3);
+        color: var(--text-soft);
     }
-
-    .trend-chip.up {
-        background: rgba(254, 242, 242, 0.16);
-        color: #fee2e2;
-        border-color: rgba(248, 113, 113, 0.45);
-    }
-
-    .trend-chip.down {
-        background: rgba(236, 253, 245, 0.16);
-        color: #d1fae5;
-        border-color: rgba(16, 185, 129, 0.45);
-    }
-
-    .trend-chip.steady {
-        background: rgba(236, 253, 245, 0.14);
-        color: #ccfbf1;
-        border-color: rgba(45, 212, 191, 0.45);
-    }
+    .trend-chip.up { color: #ffb3c4; border-color: rgba(255, 51, 102, 0.45); background: rgba(255, 51, 102, 0.08); }
+    .trend-chip.down { color: var(--accent); border-color: rgba(0, 255, 136, 0.45); background: var(--highlight); }
+    .trend-chip.steady { color: var(--accent3); border-color: rgba(61, 158, 255, 0.45); background: rgba(61, 158, 255, 0.08); }
 
     .stats-showcase {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+        gap: 0.85rem;
         margin-bottom: 2rem;
     }
-
     .stat-box {
-        background: rgba(8, 47, 73, 0.45);
-        border: 1px solid rgba(186, 230, 253, 0.3);
-        border-radius: 14px;
+        background: rgba(5, 5, 10, 0.55);
+        border: 1px solid var(--border);
+        border-left: 2px solid rgba(0, 255, 136, 0.45);
+        border-radius: var(--border-radius);
         padding: 1rem 1.1rem;
-        backdrop-filter: blur(7px);
     }
-
     .stat-label {
         display: block;
-        font-size: 0.75rem;
+        font-family: var(--font-mono);
+        font-size: 0.68rem;
         text-transform: uppercase;
-        letter-spacing: 0.07em;
-        color: #bfdbfe;
-        margin-bottom: 0.35rem;
+        letter-spacing: 0.12em;
+        color: var(--muted);
+        margin-bottom: 0.4rem;
     }
-
     .stat-number {
         display: block;
-        font-size: clamp(1.35rem, 2.8vw, 1.95rem);
-        color: #f8fafc;
-        font-weight: 700;
-        line-height: 1.2;
+        font-family: var(--font-display);
+        font-size: clamp(1.7rem, 3vw, 2.3rem);
+        letter-spacing: 1px;
+        color: var(--accent);
+        line-height: 1.1;
     }
 
-    .hero-cta {
-        display: flex;
-        gap: 0.75rem;
-        flex-wrap: wrap;
-    }
-
+    .hero-cta { display: flex; gap: 0.7rem; flex-wrap: wrap; }
     .cta-btn {
         display: inline-flex;
         align-items: center;
         gap: 0.45rem;
+        font-family: var(--font-mono);
+        font-size: 0.84rem;
+        letter-spacing: 0.5px;
         font-weight: 600;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         text-decoration: none;
-        padding: 0.8rem 1.1rem;
-        transition: transform 0.2s ease, box-shadow 0.2s ease;
+        padding: 0.75rem 1.15rem;
+        border: 1px solid var(--border);
+        transition: transform 0.18s ease, border-color 0.18s ease, color 0.18s ease, background 0.18s ease;
     }
-
-    .cta-btn:hover {
-        transform: translateY(-2px);
-    }
-
+    .cta-btn:hover { transform: translateY(-2px); }
     .cta-btn.primary {
-        background: #f8fafc;
-        color: #0f172a;
-        box-shadow: 0 10px 18px rgba(8, 47, 73, 0.2);
+        background: var(--accent);
+        color: #05140d;
+        border-color: var(--accent);
+        box-shadow: 0 0 22px rgba(0, 255, 136, 0.25);
     }
+    .cta-btn.primary:hover { background: var(--accent-dim); color: #05140d; }
+    .cta-btn.secondary { background: var(--surface-2); color: var(--text-soft); }
+    .cta-btn.secondary:hover { color: var(--accent3); border-color: var(--accent3); background: rgba(61, 158, 255, 0.08); }
 
-    .cta-btn.secondary {
-        background: rgba(8, 47, 73, 0.35);
-        color: #e2f2ff;
-        border: 1px solid rgba(186, 230, 253, 0.4);
-    }
-
+    /* ---- Insight grid --------------------------------------------- */
     .insight-grid {
         display: grid;
         grid-template-columns: 1.05fr 0.95fr;
         gap: 1.5rem;
         margin-bottom: 2.5rem;
     }
-
     .intel-panel {
-        background: #ffffff;
-        border: 1px solid #dbeafe;
-        border-radius: 16px;
-        box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
-        padding: 1.3rem;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
+        padding: 1.4rem;
     }
-
     .panel-title {
         margin: 0;
-        font-size: 1.3rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        font-size: 1.5rem;
+        letter-spacing: 1px;
+        color: var(--accent);
+        border-bottom: none;
     }
+    .panel-subtitle { margin: 0.35rem 0 1.1rem 0; color: var(--muted); font-size: 0.9rem; }
 
-    .panel-subtitle {
-        margin: 0.35rem 0 1rem 0;
-        color: #64748b;
-        font-size: 0.95rem;
-    }
-
-    .correlation-list {
-        display: grid;
-        gap: 0.8rem;
-    }
-
+    .correlation-list { display: grid; gap: 0.7rem; }
     .correlation-item {
-        border: 1px solid #e2e8f0;
-        border-radius: 12px;
-        background: #f8fafc;
-        padding: 0.9rem 0.95rem;
+        border: 1px solid var(--border);
+        border-left: 2px solid rgba(255, 51, 102, 0.5);
+        border-radius: var(--border-radius);
+        background: var(--surface-2);
+        padding: 0.85rem 0.95rem;
     }
+    .correlation-head { display: flex; justify-content: space-between; align-items: baseline; gap: 0.75rem; margin-bottom: 0.3rem; }
+    .correlation-title { margin: 0; font-size: 0.95rem; color: var(--text); }
+    .correlation-metric { margin: 0; font-family: var(--font-mono); color: var(--accent2); font-weight: 700; font-size: 0.9rem; }
+    .correlation-detail { margin: 0; font-size: 0.84rem; color: var(--muted); }
 
-    .correlation-head {
-        display: flex;
-        justify-content: space-between;
-        align-items: baseline;
-        gap: 0.75rem;
-        margin-bottom: 0.3rem;
-    }
+    .signal-list { display: grid; gap: 0.7rem; }
+    .signal-row { border: 1px solid var(--border); border-radius: var(--border-radius); padding: 0.7rem 0.8rem; background: var(--surface-2); }
+    .signal-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 0.5rem; gap: 0.6rem; }
+    .signal-name { margin: 0; font-size: 0.88rem; color: var(--text); }
+    .signal-metric { margin: 0; font-family: var(--font-mono); font-size: 0.78rem; color: var(--accent3); font-weight: 500; }
+    .signal-bar { height: 6px; background: var(--surface-3); border-radius: 999px; overflow: hidden; }
+    .signal-bar-fill { height: 100%; background: linear-gradient(90deg, var(--accent-dim), var(--accent)); border-radius: 999px; box-shadow: 0 0 8px rgba(0,255,136,0.4); }
 
-    .correlation-title {
-        margin: 0;
-        font-size: 0.98rem;
-        color: #0f172a;
-    }
-
-    .correlation-metric {
-        margin: 0;
-        color: #0f766e;
-        font-weight: 700;
-        font-size: 0.94rem;
-    }
-
-    .correlation-detail {
-        margin: 0;
-        font-size: 0.86rem;
-        color: #475569;
-    }
-
-    .signal-list {
-        display: grid;
-        gap: 0.78rem;
-    }
-
-    .signal-row {
-        border: 1px solid #e2e8f0;
-        border-radius: 11px;
-        padding: 0.72rem 0.78rem;
-        background: #ffffff;
-    }
-
-    .signal-head {
-        display: flex;
-        justify-content: space-between;
-        align-items: baseline;
-        margin-bottom: 0.45rem;
-        gap: 0.6rem;
-    }
-
-    .signal-name {
-        margin: 0;
-        font-size: 0.9rem;
-        color: #0f172a;
-    }
-
-    .signal-metric {
-        margin: 0;
-        font-size: 0.82rem;
-        color: #0369a1;
-        font-weight: 600;
-    }
-
-    .signal-bar {
-        height: 7px;
-        background: #e2e8f0;
-        border-radius: 999px;
-        overflow: hidden;
-    }
-
-    .signal-bar-fill {
-        height: 100%;
-        background: linear-gradient(90deg, #0e7490, #0891b2);
-        border-radius: 999px;
-    }
-
-    .recent-activity {
-        margin-bottom: 2.8rem;
-    }
-
-    .section-header {
-        margin-bottom: 1.1rem;
-    }
-
+    /* ---- Recent activity ------------------------------------------ */
+    .recent-activity { margin-bottom: 2.8rem; }
+    .section-header { margin-bottom: 1.2rem; }
     .section-title {
         margin: 0;
-        font-size: clamp(1.4rem, 2.6vw, 1.95rem);
+        font-family: var(--font-display);
+        font-weight: 400;
+        font-size: clamp(1.6rem, 2.8vw, 2.2rem);
+        letter-spacing: 1.5px;
+        color: var(--text);
         border-bottom: none;
     }
+    .section-subtitle { margin-top: 0.35rem; color: var(--muted); font-size: 0.9rem; }
 
-    .section-subtitle {
-        margin-top: 0.35rem;
-        color: #64748b;
-        font-size: 0.95rem;
-    }
-
-    .timeline-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 0.9rem;
-        margin-bottom: 1.4rem;
-    }
-
+    .timeline-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 0.85rem; margin-bottom: 1.4rem; }
     .timeline-card {
-        background: #ffffff;
-        border: 1px solid #dbeafe;
-        border-radius: 12px;
-        padding: 0.9rem;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        padding: 0.95rem;
+        transition: border-color 0.18s ease;
     }
+    .timeline-card:hover { border-color: var(--accent); }
+    .timeline-date { font-family: var(--font-mono); font-size: 0.78rem; color: var(--accent); font-weight: 600; margin-bottom: 0.5rem; }
+    .timeline-metrics { display: flex; justify-content: space-between; gap: 0.6rem; margin-bottom: 0.5rem; }
+    .timeline-metrics span { font-family: var(--font-mono); font-size: 0.8rem; color: var(--text-soft); }
+    .timeline-rate-bar { height: 6px; border-radius: 999px; background: var(--surface-3); overflow: hidden; }
+    .timeline-rate-fill { height: 100%; border-radius: 999px; background: linear-gradient(90deg, var(--accent3), var(--accent)); }
 
-    .timeline-date {
-        font-size: 0.8rem;
-        color: #0f766e;
-        font-weight: 700;
-        margin-bottom: 0.45rem;
-    }
-
-    .timeline-metrics {
-        display: flex;
-        justify-content: space-between;
-        gap: 0.6rem;
-        margin-bottom: 0.5rem;
-    }
-
-    .timeline-metrics span {
-        font-size: 0.82rem;
-        color: #334155;
-    }
-
-    .timeline-rate-bar {
-        height: 7px;
-        border-radius: 999px;
-        background: #e2e8f0;
-        overflow: hidden;
-    }
-
-    .timeline-rate-fill {
-        height: 100%;
-        border-radius: 999px;
-        background: linear-gradient(90deg, #0284c7, #0ea5a4);
-    }
-
-    .activity-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-        gap: 0.95rem;
-    }
-
+    .activity-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 0.9rem; }
     .activity-card {
-        background: #ffffff;
-        border: 1px solid #dbeafe;
-        border-radius: 12px;
-        padding: 1rem;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        padding: 1.1rem;
+        transition: transform 0.2s ease, border-color 0.2s ease;
     }
+    .activity-card:hover { transform: translateY(-3px); border-color: var(--accent); }
+    .activity-date { font-family: var(--font-mono); color: var(--accent3); font-size: 0.8rem; font-weight: 600; margin-bottom: 0.4rem; }
+    .activity-title { font-size: 1rem; margin: 0 0 0.8rem 0; color: var(--text); }
+    .activity-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.45rem; margin-bottom: 0.8rem; }
+    .activity-stats .mini-stat { min-width: 0; width: 100%; flex: initial; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius); padding: 0.5rem; text-align: center; }
+    .activity-stats .mini-stat-value { display: block; font-family: var(--font-display); font-size: 1.3rem; color: var(--accent); }
+    .activity-stats .mini-stat-label { display: block; font-family: var(--font-mono); font-size: 0.62rem; color: var(--muted); text-transform: uppercase; letter-spacing: 1px; }
+    .view-report-btn { display: inline-flex; align-items: center; gap: 0.35rem; font-family: var(--font-mono); font-size: 0.82rem; font-weight: 600; color: var(--accent); }
+    .activity-actions { text-align: center; margin-top: 1.3rem; }
 
-    .activity-date {
-        color: #0369a1;
-        font-size: 0.82rem;
-        font-weight: 700;
-        margin-bottom: 0.4rem;
-    }
-
-    .activity-title {
-        font-size: 1.02rem;
-        margin: 0 0 0.7rem 0;
-    }
-
-    .activity-stats {
-        display: grid;
-        grid-template-columns: repeat(3, 1fr);
-        gap: 0.45rem;
-        margin-bottom: 0.75rem;
-    }
-
-    .activity-stats .mini-stat {
-        min-width: 0;
-        width: 100%;
-        flex: initial;
-        background: #f8fafc;
-        border-radius: 8px;
-        padding: 0.45rem;
-        text-align: center;
-    }
-
-    .activity-stats .mini-stat-value {
-        display: block;
-        font-size: 1.02rem;
-        color: #0f172a;
-        font-weight: 700;
-    }
-
-    .activity-stats .mini-stat-label {
-        display: block;
-        font-size: 0.7rem;
-        color: #64748b;
-        text-transform: uppercase;
-    }
-
-    .view-report-btn {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.35rem;
-        font-weight: 600;
-        color: #0e7490;
-    }
-
-    .activity-actions {
-        text-align: center;
-        margin-top: 1.1rem;
-    }
-
+    /* ---- Features ------------------------------------------------- */
     .features-section {
-        background: linear-gradient(160deg, #ecfeff 0%, #f8fafc 42%, #ecfeff 100%);
-        border: 1px solid #dbeafe;
-        border-radius: 16px;
-        padding: 1.45rem;
+        background: linear-gradient(160deg, var(--surface) 0%, var(--surface-2) 100%);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        padding: 1.6rem;
         margin-bottom: 2.4rem;
     }
-
-    .features-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 0.8rem;
-        margin-top: 0.95rem;
-    }
-
+    .features-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 0.85rem; margin-top: 1rem; }
     .feature-card {
-        border-radius: 11px;
-        background: #ffffff;
-        border: 1px solid #e2e8f0;
-        padding: 0.9rem;
+        border-radius: var(--border-radius);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-top: 2px solid rgba(0, 255, 136, 0.4);
+        padding: 1.05rem;
+        transition: border-color 0.18s ease, transform 0.18s ease;
     }
+    .feature-card:hover { border-color: var(--accent); transform: translateY(-2px); }
+    .feature-title { margin: 0 0 0.4rem 0; font-family: var(--font-mono); font-size: 0.9rem; letter-spacing: 0.5px; color: var(--accent); border-bottom: none; }
+    .feature-description { margin: 0; font-size: 0.86rem; color: var(--muted); }
 
-    .feature-title {
-        margin: 0 0 0.35rem 0;
-        font-size: 1rem;
-        border-bottom: none;
-    }
-
-    .feature-description {
-        margin: 0;
-        font-size: 0.88rem;
-        color: #475569;
-    }
-
+    /* ---- CTA ------------------------------------------------------ */
     .cta-section {
-        background: #0f172a;
-        border-radius: 16px;
-        padding: 1.5rem;
-        color: #e2e8f0;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        border-radius: var(--border-radius);
+        padding: 1.75rem;
+        color: var(--text-soft);
         margin-bottom: 0.5rem;
     }
-
     .cta-section h2 {
-        color: #f8fafc;
+        color: var(--text);
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
         margin: 0 0 0.65rem 0;
         border-bottom: none;
     }
+    .cta-section p { color: var(--muted); margin-bottom: 1.2rem; }
 
-    .cta-section p {
-        color: #cbd5e1;
-        margin-bottom: 1rem;
-    }
-
-    @media (max-width: 980px) {
-        .insight-grid {
-            grid-template-columns: 1fr;
-        }
-    }
-
+    @media (max-width: 980px) { .insight-grid { grid-template-columns: 1fr; } }
     @media (max-width: 768px) {
-        .intel-hero {
-            padding: 2.3rem 1.2rem;
-        }
-
-        .activity-stats {
-            grid-template-columns: 1fr;
-        }
+        .intel-hero { padding: 2.3rem 1.2rem; }
+        .activity-stats { grid-template-columns: 1fr; }
     }
 </style>
 
@@ -515,7 +341,7 @@
 <section class="intel-hero">
     <div class="intel-hero-content">
         <div class="hero-kicker">Live Threat Surface</div>
-        <h1 class="hero-title">ClickGrab Threat Intelligence, rebuilt for speed and clarity</h1>
+        <h1 class="hero-title">ClickGrab Threat Intelligence</h1>
         <p class="hero-subtitle">
             Daily telemetry from ClickFix and FakeCAPTCHA campaigns, correlated into one view so teams can spot the chain:
             social lure, clipboard abuse, and execution behavior.

--- a/public/mitigations.html
+++ b/public/mitigations.html
@@ -5,231 +5,270 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mitigations - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .mitigations-header {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .mitigations-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .mitigations-subtitle {
         font-size: 1.2rem;
-        color: rgba(255, 255, 255, 0.9);
+        color: var(--text-soft);
         max-width: 600px;
         margin: 0 auto;
         line-height: 1.6;
     }
-    
+
     .mitigation-section {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
         margin-bottom: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
     }
-    
+
     .mitigation-section h2 {
-        color: #333;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin-bottom: 1.5rem;
         font-size: 1.8rem;
         display: flex;
         align-items: center;
         gap: 0.5rem;
     }
-    
+
+    .mitigation-section h2 i {
+        color: var(--accent);
+    }
+
     .mitigation-section h3 {
-        color: #555;
+        color: var(--text-soft);
         margin-bottom: 1rem;
         font-size: 1.3rem;
         margin-top: 2rem;
     }
-    
+
     .mitigation-section h3:first-child {
         margin-top: 0;
     }
-    
+
+    .mitigation-section p,
+    .mitigation-section li {
+        color: var(--text-soft);
+    }
+
+    .mitigation-section a {
+        color: var(--accent3);
+        text-decoration: none;
+    }
+
+    .mitigation-section a:hover {
+        color: var(--accent);
+        text-decoration: underline;
+    }
+
     .code-block {
-        background: #f8f9fa;
-        border: 1px solid #e9ecef;
-        border-radius: 8px;
+        background: #05050a;
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
+        border-radius: var(--border-radius);
         padding: 1.5rem;
         margin: 1rem 0;
-        font-family: 'Courier New', monospace;
+        font-family: var(--font-mono);
         font-size: 0.9rem;
         line-height: 1.5;
+        color: var(--accent3);
         overflow-x: auto;
     }
-    
+
     .warning-box {
-        background: #fff3cd;
-        border: 1px solid #ffeaa7;
-        border-radius: 8px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 1rem;
         margin: 1rem 0;
-        border-left: 4px solid #f39c12;
+        border-left: 3px solid var(--accent4);
+        color: var(--text-soft);
     }
-    
+
     .info-box {
-        background: #d1ecf1;
-        border: 1px solid #bee5eb;
-        border-radius: 8px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 1rem;
         margin: 1rem 0;
-        border-left: 4px solid #17a2b8;
+        border-left: 3px solid var(--accent3);
+        color: var(--text-soft);
     }
-    
+
     .tool-card {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface-2);
+        border-radius: var(--border-radius);
         padding: 1.5rem;
         margin: 1rem 0;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-        border: 1px solid #e1e5e9;
-        transition: transform 0.2s ease, box-shadow 0.2s ease;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        transition: transform 0.18s ease, border-color 0.18s ease;
     }
-    
+
     .tool-card:hover {
         transform: translateY(-2px);
-        box-shadow: 0 4px 20px rgba(0,0,0,0.15);
+        border-color: var(--accent);
     }
-    
+
     .tool-header {
         display: flex;
         align-items: center;
         gap: 1rem;
         margin-bottom: 1rem;
     }
-    
+
     .tool-icon {
         width: 48px;
         height: 48px;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        border-radius: 12px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         display: flex;
         align-items: center;
         justify-content: center;
-        color: white;
+        color: var(--accent);
         font-size: 1.5rem;
     }
-    
+
     .tool-title {
+        font-family: var(--font-display);
         font-size: 1.3rem;
-        font-weight: 600;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .tool-description {
-        color: #666;
+        color: var(--text-soft);
         line-height: 1.6;
         margin-bottom: 1rem;
     }
-    
+
     .tool-links {
         display: flex;
         gap: 1rem;
         flex-wrap: wrap;
     }
-    
+
     .tool-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: #f8f9fa;
-        border: 1px solid #e9ecef;
-        border-radius: 6px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         text-decoration: none;
-        color: #495057;
+        color: var(--text-soft);
+        font-family: var(--font-mono);
         font-size: 0.9rem;
-        transition: all 0.2s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .tool-link:hover {
-        background: #e9ecef;
-        color: #333;
+        background: var(--surface-3);
+        border-color: var(--accent);
+        color: var(--accent);
         text-decoration: none;
     }
-    
+
     .tool-link.github {
-        background: #24292e;
-        color: white;
-        border-color: #24292e;
+        background: var(--surface-3);
+        color: var(--text);
+        border-color: var(--border);
     }
-    
+
     .tool-link.github:hover {
-        background: #1a1e22;
-        color: white;
+        border-color: var(--accent);
+        color: var(--accent);
     }
-    
+
     .contributor-info {
-        background: #f8f9fa;
-        border-radius: 8px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 1rem;
         margin: 1rem 0;
-        border-left: 4px solid #28a745;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .contributor-name {
+        font-family: var(--font-mono);
         font-weight: 600;
-        color: #28a745;
+        letter-spacing: 0.5px;
+        color: var(--accent);
         margin-bottom: 0.5rem;
     }
-    
+
     .contributor-links {
         display: flex;
         gap: 1rem;
         flex-wrap: wrap;
     }
-    
+
     .contributor-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
+        font-family: var(--font-mono);
         font-size: 0.9rem;
     }
-    
+
     .contributor-link:hover {
+        color: var(--accent);
         text-decoration: underline;
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
+        font-family: var(--font-mono);
         font-weight: 500;
+        letter-spacing: 0.5px;
         margin-bottom: 2rem;
-        transition: color 0.2s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .back-link:hover {
-        color: #5a6fd8;
+        color: var(--accent);
         text-decoration: none;
     }
     

--- a/public/reports.html
+++ b/public/reports.html
@@ -5,29 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ClickGrab - Threat Intelligence Reports Archive</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <style>
     /* Page Header */
     .reports-hero {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 4rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
         position: relative;
         overflow: hidden;
+        box-shadow: var(--shadow);
     }
-    
+
     .reports-hero::after {
         content: '';
         position: absolute;
@@ -35,25 +35,27 @@
         left: 0;
         right: 0;
         height: 100px;
-        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 320"><path fill="rgba(255,255,255,0.1)" d="M0,96L48,112C96,128,192,160,288,165.3C384,171,480,149,576,138.7C672,128,768,128,864,144C960,160,1056,192,1152,186.7C1248,181,1344,139,1392,117.3L1440,96L1440,320L1392,320C1344,320,1248,320,1152,320C1056,320,960,320,864,320C768,320,672,320,576,320C480,320,384,320,288,320C192,320,96,320,48,320L0,320Z"></path></svg>') no-repeat;
+        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 320"><path fill="rgba(0,255,136,0.06)" d="M0,96L48,112C96,128,192,160,288,165.3C384,171,480,149,576,138.7C672,128,768,128,864,144C960,160,1056,192,1152,186.7C1248,181,1344,139,1392,117.3L1440,96L1440,320L1392,320C1344,320,1248,320,1152,320C1056,320,960,320,864,320C768,320,672,320,576,320C480,320,384,320,288,320C192,320,96,320,48,320L0,320Z"></path></svg>') no-repeat;
         background-size: cover;
         pointer-events: none;
     }
-    
+
     .reports-hero h1 {
+        font-family: var(--font-display);
         font-size: 2.5rem;
         margin-bottom: 1rem;
-        font-weight: 700;
+        font-weight: 400;
+        letter-spacing: 2px;
+        color: var(--accent);
     }
-    
+
     .reports-hero p {
         font-size: 1.2rem;
-        color: rgba(255, 255, 255, 0.95);
+        color: var(--text-soft);
         max-width: 600px;
         margin: 0 auto;
-        text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
     }
-    
+
     /* Stats Summary */
     .reports-summary {
         display: grid;
@@ -62,93 +64,108 @@
         max-width: 600px;
         margin: 2rem auto 0;
     }
-    
+
     .summary-stat {
-        background: rgba(255,255,255,0.1);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         text-align: center;
     }
-    
+
     .summary-stat-value {
+        font-family: var(--font-mono);
         font-size: 2rem;
         font-weight: 700;
         display: block;
+        color: var(--accent);
     }
-    
+
     .summary-stat-label {
+        font-family: var(--font-mono);
         font-size: 0.85rem;
-        opacity: 0.9;
+        color: var(--muted);
         text-transform: uppercase;
         letter-spacing: 0.5px;
     }
-    
+
     /* Executive Summary & Key Findings */
     .executive-section {
-        background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
-        border-radius: 16px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 2rem;
         margin-bottom: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border: 1px solid #e2e8f0;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .executive-header {
         display: flex;
         align-items: center;
         gap: 1rem;
         margin-bottom: 1.5rem;
     }
-    
+
     .executive-icon {
         width: 48px;
         height: 48px;
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        border-radius: 12px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         display: flex;
         align-items: center;
         justify-content: center;
         font-size: 24px;
         flex-shrink: 0;
     }
-    
+
     .executive-title {
+        font-family: var(--font-display);
         font-size: 1.75rem;
-        font-weight: 700;
-        color: var(--text-color);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
     }
-    
+
     .executive-content {
-        color: var(--text-light);
+        color: var(--text-soft);
         line-height: 1.8;
         font-size: 1.05rem;
     }
-    
+
     .key-findings {
-        background: white;
-        border-radius: 16px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 2rem;
         margin-bottom: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border: 1px solid #e2e8f0;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
     }
-    
+
     .findings-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
         gap: 1.5rem;
         margin-top: 1.5rem;
     }
-    
+
     .finding-card {
-        background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+        background: var(--surface-2);
         padding: 1.5rem;
-        border-radius: 12px;
-        border: 1px solid #e2e8f0;
+        border-radius: var(--border-radius);
+        border: 1px solid var(--border);
         position: relative;
         overflow: hidden;
+        transition: all 0.18s ease;
     }
-    
+
+    .finding-card:hover {
+        transform: translateY(-2px);
+        border-color: var(--accent);
+    }
+
     .finding-card::before {
         content: '';
         position: absolute;
@@ -156,152 +173,163 @@
         left: 0;
         width: 4px;
         height: 100%;
-        background: linear-gradient(180deg, #0e7490, #0f766e);
+        background: var(--accent);
     }
-    
+
     .finding-icon {
         width: 40px;
         height: 40px;
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        border-radius: 10px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         display: flex;
         align-items: center;
         justify-content: center;
         margin-bottom: 1rem;
         font-size: 20px;
     }
-    
+
     .finding-title {
         font-size: 1.1rem;
         font-weight: 600;
-        color: var(--text-color);
+        color: var(--text);
         margin-bottom: 0.5rem;
     }
-    
+
     .finding-value {
+        font-family: var(--font-mono);
         font-size: 2rem;
         font-weight: 700;
-        color: #0e7490;
+        color: var(--accent);
         margin-bottom: 0.5rem;
     }
-    
+
     .finding-desc {
         font-size: 0.9rem;
-        color: var(--text-light);
+        color: var(--muted);
         line-height: 1.5;
     }
-    
+
     .finding-trend {
         display: inline-flex;
         align-items: center;
         gap: 0.25rem;
+        font-family: var(--font-mono);
         font-size: 0.85rem;
         font-weight: 600;
         margin-top: 0.5rem;
     }
-    
+
     .trend-up {
-        color: #ef4444;
+        color: var(--accent2);
     }
-    
+
     .trend-down {
-        color: #22c55e;
+        color: var(--accent);
     }
-    
+
     /* Table of Contents */
     .toc-section {
-        background: white;
-        border-radius: 16px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 2rem;
         margin-bottom: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border: 1px solid #e2e8f0;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .toc-header {
         display: flex;
         align-items: center;
         gap: 1rem;
         margin-bottom: 1.5rem;
     }
-    
+
     .toc-grid {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
         gap: 1rem;
     }
-    
+
     .toc-item {
-        background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         text-decoration: none;
-        color: var(--text-color);
-        transition: all 0.3s ease;
-        border: 1px solid #e2e8f0;
+        color: var(--text);
+        transition: all 0.18s ease;
+        border: 1px solid var(--border);
         display: flex;
         flex-direction: column;
         gap: 0.25rem;
     }
-    
+
     .toc-item:hover {
-        transform: translateY(-3px);
-        box-shadow: 0 8px 20px rgba(0,0,0,0.12);
-        border-color: #0e7490;
-        color: var(--text-color);
+        transform: translateY(-2px);
+        box-shadow: var(--shadow);
+        border-color: var(--accent);
+        color: var(--text);
     }
-    
+
     .toc-month {
         font-weight: 600;
         font-size: 1.1rem;
+        color: var(--text);
     }
-    
+
     .toc-stats {
+        font-family: var(--font-mono);
         font-size: 0.85rem;
-        color: var(--text-light);
+        color: var(--muted);
     }
-    
+
     .toc-highlight {
+        font-family: var(--font-mono);
         font-size: 0.75rem;
-        color: #0e7490;
+        color: var(--accent);
         font-weight: 500;
     }
-    
+
     /* Month Groups */
     .month-section {
         margin-bottom: 3rem;
         scroll-margin-top: 80px;
     }
-    
+
     .month-header {
         display: flex;
         align-items: center;
         justify-content: space-between;
         margin-bottom: 1.5rem;
         padding-bottom: 0.75rem;
-        border-bottom: 2px solid #e5e7eb;
+        border-bottom: 2px solid var(--accent);
     }
-    
+
     .month-title {
+        font-family: var(--font-display);
         font-size: 1.75rem;
-        font-weight: 600;
-        color: var(--text-color);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
     }
-    
+
     .month-stats {
         display: flex;
         gap: 1.5rem;
+        font-family: var(--font-mono);
         font-size: 0.9rem;
-        color: var(--text-light);
+        color: var(--muted);
     }
-    
+
     /* Back to Top Button */
     .back-to-top {
         position: fixed;
         bottom: 2rem;
         right: 2rem;
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        color: white;
+        background: var(--surface-2);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         width: 48px;
         height: 48px;
         border-radius: 50%;
@@ -309,246 +337,273 @@
         align-items: center;
         justify-content: center;
         text-decoration: none;
-        box-shadow: 0 4px 20px rgba(102, 126, 234, 0.4);
-        transition: all 0.3s ease;
+        box-shadow: var(--shadow);
+        transition: all 0.18s ease;
         opacity: 0;
         pointer-events: none;
         z-index: 100;
     }
-    
+
     .back-to-top.visible {
         opacity: 1;
         pointer-events: all;
     }
-    
+
     .back-to-top:hover {
-        transform: translateY(-3px);
-        box-shadow: 0 8px 30px rgba(102, 126, 234, 0.5);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--surface-3);
+        box-shadow: var(--shadow);
+        color: var(--accent);
     }
-    
+
     /* Report Cards */
     .reports-grid {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
         gap: 1.5rem;
     }
-    
+
     .report-card {
-        background: white;
-        border-radius: 12px;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.08);
+        background: var(--surface);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
         overflow: hidden;
-        transition: all 0.3s ease;
-        border: 1px solid #e5e7eb;
+        transition: all 0.18s ease;
+        border: 1px solid var(--border);
         position: relative;
     }
-    
+
     .report-card:hover {
-        transform: translateY(-5px);
-        box-shadow: 0 8px 25px rgba(0,0,0,0.12);
-        border-color: #0e7490;
+        transform: translateY(-2px);
+        box-shadow: var(--shadow);
+        border-color: var(--accent);
     }
-    
+
     .report-header {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-2);
+        border-bottom: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 1.25rem;
         position: relative;
     }
-    
+
     .report-date {
+        font-family: var(--font-mono);
         font-size: 0.85rem;
-        opacity: 1;
-        color: #FFFFFF !important;
+        color: var(--muted) !important;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
         margin-bottom: 0.25rem;
     }
-    
+
     .report-title {
         font-size: 1.25rem;
         font-weight: 600;
         margin: 0;
+        color: var(--text);
     }
-    
+
     .threat-badge {
         position: absolute;
         top: 1rem;
         right: 1rem;
         padding: 0.25rem 0.75rem;
-        border-radius: 20px;
+        border-radius: var(--border-radius);
+        font-family: var(--font-mono);
         font-size: 0.75rem;
         font-weight: 600;
-        background: rgba(255,255,255,0.2);
-        backdrop-filter: blur(5px);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
-    
+
     .threat-badge.high {
-        background: rgba(239, 68, 68, 0.9);
+        background: rgba(255, 51, 102, 0.15);
+        border-color: var(--accent2);
+        color: var(--accent2);
     }
-    
+
     .threat-badge.medium {
-        background: rgba(245, 158, 11, 0.9);
+        background: rgba(255, 204, 0, 0.12);
+        border-color: var(--accent4);
+        color: var(--accent4);
     }
-    
+
     .threat-badge.low {
-        background: rgba(34, 197, 94, 0.9);
+        background: rgba(0, 255, 136, 0.12);
+        border-color: var(--accent);
+        color: var(--accent);
     }
-    
+
     .report-body {
         padding: 1.5rem;
     }
-    
+
     .report-metrics {
         display: grid;
         grid-template-columns: repeat(2, 1fr);
         gap: 1rem;
         margin-bottom: 1.5rem;
     }
-    
+
     .metric {
         text-align: center;
         padding: 0.75rem;
-        background: #f9fafb;
-        border-radius: 8px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .metric-value {
+        font-family: var(--font-mono);
         font-size: 1.5rem;
         font-weight: 700;
-        color: #0e7490;
+        color: var(--accent);
         display: block;
     }
-    
+
     .metric-label {
+        font-family: var(--font-mono);
         font-size: 0.75rem;
-        color: var(--text-light);
+        color: var(--muted);
         text-transform: uppercase;
         letter-spacing: 0.5px;
     }
-    
+
     .report-highlights {
         margin-bottom: 1.5rem;
     }
-    
+
     .highlight-item {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         margin-bottom: 0.5rem;
         font-size: 0.9rem;
-        color: var(--text-color);
+        color: var(--text-soft);
     }
-    
+
     .highlight-icon {
-        color: #0e7490;
+        color: var(--accent);
         flex-shrink: 0;
     }
-    
+
     .view-report-link {
         display: block;
         text-align: center;
-        background: #0e7490;
-        color: white;
+        background: var(--accent);
+        color: var(--bg);
         padding: 0.75rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         text-decoration: none;
+        font-family: var(--font-mono);
         font-weight: 600;
-        transition: background 0.2s ease;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        transition: all 0.18s ease;
     }
-    
+
     .view-report-link:hover {
-        background: #5a5fbf;
-        color: white;
+        background: var(--accent-dim);
+        color: var(--bg);
     }
-    
+
     /* Filters */
     .filters-section {
-        background: white;
+        background: var(--surface);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.08);
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
     }
-    
+
     .filters-row {
         display: flex;
         gap: 1rem;
         flex-wrap: wrap;
         align-items: center;
     }
-    
+
     .filter-group {
         flex: 1;
         min-width: 200px;
     }
-    
+
     .filter-label {
         display: block;
         margin-bottom: 0.5rem;
+        font-family: var(--font-mono);
         font-size: 0.9rem;
         font-weight: 500;
-        color: var(--text-color);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        color: var(--muted);
     }
-    
+
     .filter-select {
         width: 100%;
         padding: 0.5rem 1rem;
-        border: 1px solid #e5e7eb;
-        border-radius: 8px;
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         font-size: 0.95rem;
-        background: white;
-        transition: border-color 0.2s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        transition: border-color 0.18s ease;
     }
-    
+
     .filter-select:focus {
         outline: none;
-        border-color: #0e7490;
+        border-color: var(--accent);
     }
-    
+
     /* Empty State */
     .empty-state {
         text-align: center;
         padding: 4rem 2rem;
-        color: var(--text-light);
+        color: var(--muted);
     }
-    
+
     .empty-state-icon {
         font-size: 3rem;
         margin-bottom: 1rem;
         opacity: 0.5;
     }
-    
+
     /* Responsive */
     @media (max-width: 768px) {
         .reports-hero h1 {
             font-size: 2rem;
         }
-        
+
         .reports-grid {
             grid-template-columns: 1fr;
         }
-        
+
         .month-header {
             flex-direction: column;
             gap: 1rem;
             align-items: flex-start;
         }
-        
+
         .filters-row {
             flex-direction: column;
         }
-        
+
         .filter-group {
             width: 100%;
         }
     }
-    
+
     /* Loading Animation */
     .loading {
         opacity: 0.6;
         pointer-events: none;
     }
-    
+
     .loading::after {
         content: '';
         position: absolute;
@@ -557,12 +612,12 @@
         width: 40px;
         height: 40px;
         margin: -20px 0 0 -20px;
-        border: 3px solid #f3f3f3;
-        border-top: 3px solid #0e7490;
+        border: 3px solid var(--border);
+        border-top: 3px solid var(--accent);
         border-radius: 50%;
         animation: spin 1s linear infinite;
     }
-    
+
     @keyframes spin {
         0% { transform: rotate(0deg); }
         100% { transform: rotate(360deg); }
@@ -1905,66 +1960,6 @@
             </div>
             
             <div class="report-card" 
-                 data-threats="42"
-                 data-powershell="19"
-                 data-high-risk="20"
-                 data-score="0">
-                
-                <div class="report-header">
-                    <div class="report-date">May 12, 2026</div>
-                    <h3 class="report-title">Daily Threat Report</h3>
-                    
-                    
-                    <span class="threat-badge high">High Threat</span>
-                    
-                </div>
-                
-                <div class="report-body">
-                    <div class="report-metrics">
-                        <div class="metric">
-                            <span class="metric-value">42</span>
-                            <span class="metric-label">Threats</span>
-                        </div>
-                        <div class="metric">
-                            <span class="metric-value">100</span>
-                            <span class="metric-label">Sites</span>
-                        </div>
-                        <div class="metric">
-                            <span class="metric-value">0</span>
-                            <span class="metric-label">Avg Score</span>
-                        </div>
-                        <div class="metric">
-                            <span class="metric-value">42.0%</span>
-                            <span class="metric-label">Detection</span>
-                        </div>
-                    </div>
-                    
-                    <div class="report-highlights">
-                        
-                        <div class="highlight-item">
-                            <span class="highlight-icon">💻</span>
-                            <span>19 PowerShell commands</span>
-                        </div>
-                        
-                        
-                        <div class="highlight-item">
-                            <span class="highlight-icon">⚠️</span>
-                            <span>20 high-risk commands</span>
-                        </div>
-                        
-                        <div class="highlight-item">
-                            <span class="highlight-icon">🎯</span>
-                            <span>Automated threat detection</span>
-                        </div>
-                    </div>
-                    
-                    <a href="/ClickGrab/reports/2026-05-12.html" class="view-report-link">
-                        View Detailed Analysis
-                    </a>
-                </div>
-            </div>
-            
-            <div class="report-card" 
                  data-threats="43"
                  data-powershell="19"
                  data-high-risk="21"
@@ -2019,6 +2014,66 @@
                     </div>
                     
                     <a href="/ClickGrab/reports/2026-05-13.html" class="view-report-link">
+                        View Detailed Analysis
+                    </a>
+                </div>
+            </div>
+            
+            <div class="report-card" 
+                 data-threats="42"
+                 data-powershell="19"
+                 data-high-risk="20"
+                 data-score="0">
+                
+                <div class="report-header">
+                    <div class="report-date">May 12, 2026</div>
+                    <h3 class="report-title">Daily Threat Report</h3>
+                    
+                    
+                    <span class="threat-badge high">High Threat</span>
+                    
+                </div>
+                
+                <div class="report-body">
+                    <div class="report-metrics">
+                        <div class="metric">
+                            <span class="metric-value">42</span>
+                            <span class="metric-label">Threats</span>
+                        </div>
+                        <div class="metric">
+                            <span class="metric-value">100</span>
+                            <span class="metric-label">Sites</span>
+                        </div>
+                        <div class="metric">
+                            <span class="metric-value">0</span>
+                            <span class="metric-label">Avg Score</span>
+                        </div>
+                        <div class="metric">
+                            <span class="metric-value">42.0%</span>
+                            <span class="metric-label">Detection</span>
+                        </div>
+                    </div>
+                    
+                    <div class="report-highlights">
+                        
+                        <div class="highlight-item">
+                            <span class="highlight-icon">💻</span>
+                            <span>19 PowerShell commands</span>
+                        </div>
+                        
+                        
+                        <div class="highlight-item">
+                            <span class="highlight-icon">⚠️</span>
+                            <span>20 high-risk commands</span>
+                        </div>
+                        
+                        <div class="highlight-item">
+                            <span class="highlight-icon">🎯</span>
+                            <span>Automated threat detection</span>
+                        </div>
+                    </div>
+                    
+                    <a href="/ClickGrab/reports/2026-05-12.html" class="view-report-link">
                         View Detailed Analysis
                     </a>
                 </div>

--- a/public/reports/2026-05-30.html
+++ b/public/reports/2026-05-30.html
@@ -5,28 +5,28 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ClickGrab Report - May 30, 2026</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <style>
     /* Report Header */
     .report-hero {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         position: relative;
         overflow: hidden;
+        box-shadow: var(--shadow);
     }
-    
+
     .report-hero::before {
         content: '';
         position: absolute;
@@ -34,27 +34,31 @@
         left: 0;
         right: 0;
         bottom: 0;
-        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><pattern id="grid" width="10" height="10" patternUnits="userSpaceOnUse"><path d="M 10 0 L 0 0 0 10" fill="none" stroke="rgba(255,255,255,0.1)" stroke-width="0.5"/></pattern><rect width="100" height="100" fill="url(%23grid)"/></svg>');
-        opacity: 0.3;
+        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><pattern id="grid" width="10" height="10" patternUnits="userSpaceOnUse"><path d="M 10 0 L 0 0 0 10" fill="none" stroke="rgba(0,255,136,0.06)" stroke-width="0.5"/></pattern><rect width="100" height="100" fill="url(%23grid)"/></svg>');
+        opacity: 0.5;
     }
-    
+
     .report-hero-content {
         position: relative;
         z-index: 1;
     }
-    
+
     .report-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 700;
+        font-weight: 400;
+        letter-spacing: 2px;
+        color: var(--accent);
         margin-bottom: 1rem;
     }
-    
+
     .report-meta {
         display: flex;
         gap: 2rem;
         flex-wrap: wrap;
-        font-size: 1.1rem;
-        opacity: 0.95;
+        font-family: var(--font-mono);
+        font-size: 0.95rem;
+        color: var(--text-soft);
     }
     
     /* Summary Cards */
@@ -66,78 +70,82 @@
     }
     
     .summary-card {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 1.5rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+        box-shadow: var(--shadow);
         text-align: center;
-        transition: transform 0.3s ease;
-        border: 1px solid #e5e7eb;
+        transition: transform 0.18s ease, border-color 0.18s ease;
+        border: 1px solid var(--border);
         position: relative;
         overflow: hidden;
     }
-    
+
     .summary-card::before {
         content: '';
         position: absolute;
         top: 0;
         left: 0;
         right: 0;
-        height: 4px;
-        background: linear-gradient(90deg, var(--gradient-start), var(--gradient-end));
+        height: 3px;
+        background: var(--accent-edge, var(--accent));
     }
-    
-    .summary-card.total { --gradient-start: #0e7490; --gradient-end: #0f766e; }
-    .summary-card.threats { --gradient-start: #22c55e; --gradient-end: #0891b2; }
-    .summary-card.powershell { --gradient-start: #4facfe; --gradient-end: #00f2fe; }
-    .summary-card.clipboard { --gradient-start: #fa709a; --gradient-end: #fee140; }
-    .summary-card.score { --gradient-start: #30cfd0; --gradient-end: #330867; }
-    
+
+    .summary-card.total { --accent-edge: var(--accent3); }
+    .summary-card.threats { --accent-edge: var(--accent2); }
+    .summary-card.powershell { --accent-edge: var(--accent3); }
+    .summary-card.clipboard { --accent-edge: var(--accent4); }
+    .summary-card.score { --accent-edge: var(--accent); }
+
     .summary-card:hover {
-        transform: translateY(-5px);
-        box-shadow: 0 8px 30px rgba(0,0,0,0.12);
+        transform: translateY(-2px);
+        border-color: var(--accent);
     }
-    
+
     .summary-icon {
         font-size: 2.5rem;
         margin-bottom: 1rem;
     }
-    
+
     .summary-value {
+        font-family: var(--font-mono);
         font-size: 2.5rem;
         font-weight: 700;
-        color: var(--text-color);
+        color: var(--text);
         margin-bottom: 0.5rem;
     }
-    
+
     .summary-label {
-        color: var(--text-light);
+        font-family: var(--font-mono);
+        color: var(--muted);
         font-size: 0.9rem;
         text-transform: uppercase;
         letter-spacing: 0.5px;
     }
-    
+
     .summary-change {
         margin-top: 0.5rem;
+        font-family: var(--font-mono);
         font-size: 0.85rem;
         display: flex;
         align-items: center;
         justify-content: center;
         gap: 0.25rem;
     }
-    
-    .change-up { color: #ef4444; }
-    .change-down { color: #22c55e; }
+
+    .change-up { color: var(--accent2); }
+    .change-down { color: var(--accent); }
     
     /* Threat Overview */
     .threat-overview {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
         margin-bottom: 3rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+        box-shadow: var(--shadow);
     }
-    
+
     .threat-header {
         display: flex;
         justify-content: space-between;
@@ -146,33 +154,36 @@
         flex-wrap: wrap;
         gap: 1rem;
     }
-    
+
     .threat-title {
+        font-family: var(--font-display);
         font-size: 1.75rem;
-        font-weight: 600;
-        color: var(--text-color);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
     }
-    
+
     .threat-actions {
         display: flex;
         gap: 1rem;
     }
-    
+
     .action-btn {
         padding: 0.5rem 1rem;
-        border: 1px solid #e5e7eb;
-        border-radius: 8px;
-        background: white;
-        color: var(--text-color);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        background: var(--surface-2);
+        color: var(--text-soft);
+        font-family: var(--font-mono);
         font-size: 0.9rem;
         cursor: pointer;
-        transition: all 0.2s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .action-btn:hover {
-        background: #f9fafb;
-        border-color: #0e7490;
-        color: #0e7490;
+        background: var(--surface-3);
+        border-color: var(--accent);
+        color: var(--accent);
     }
 
     /* Simple bar chart styles */
@@ -183,14 +194,14 @@
         margin-top: 1rem;
     }
     .bar {
-        background: #f9fafb;
-        border: 1px solid #e5e7eb;
-        border-radius: 8px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 0.75rem;
     }
-    .bar-label { font-size: 0.9rem; color: var(--text-light); }
-    .bar-track { height: 10px; background: #eef2ff; border-radius: 6px; margin-top: 0.5rem; overflow: hidden; }
-    .bar-fill { height: 100%; background: linear-gradient(90deg,#0e7490,#0f766e); border-radius: 6px; width: 0%; transition: width .6s ease; }
+    .bar-label { font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted); }
+    .bar-track { height: 10px; background: var(--surface-3); border-radius: 6px; margin-top: 0.5rem; overflow: hidden; }
+    .bar-fill { height: 100%; background: var(--accent); border-radius: 6px; width: 0%; transition: width .6s ease; }
     
     /* Site Analysis Cards */
     .sites-section {
@@ -205,27 +216,27 @@
     }
     
     .site-card {
-        background: white;
-        border-radius: 12px;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.08);
+        background: var(--surface);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
         margin-bottom: 1.5rem;
         overflow: hidden;
-        transition: all 0.3s ease;
-        border: 1px solid #e5e7eb;
+        transition: all 0.18s ease;
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
     }
-    
+
     .site-card:hover {
-        box-shadow: 0 4px 20px rgba(0,0,0,0.12);
-        border-color: #0e7490;
+        border-color: var(--accent);
     }
-    
+
     .site-header {
-        background: #f9fafb;
+        background: var(--surface-2);
         padding: 1.5rem;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--border);
         cursor: pointer;
     }
-    
+
     .site-header-content {
         display: flex;
         justify-content: space-between;
@@ -233,41 +244,44 @@
         flex-wrap: wrap;
         gap: 1rem;
     }
-    
+
     .site-url {
         font-weight: 600;
-        color: #ef4444;
+        color: var(--accent2);
         word-break: break-all;
-        font-family: monospace;
+        font-family: var(--font-mono);
         font-size: 0.95rem;
     }
-    
+
     .site-badges {
         display: flex;
         gap: 0.5rem;
         flex-wrap: wrap;
     }
-    
+
     .threat-score-badge {
         padding: 0.25rem 0.75rem;
         border-radius: 20px;
+        font-family: var(--font-mono);
         font-size: 0.8rem;
         font-weight: 600;
-        color: white;
+        color: var(--bg);
     }
-    
-    .score-critical { background: #dc2626; }
-    .score-high { background: #ef4444; }
-    .score-medium { background: #f59e0b; }
-    .score-low { background: #3b82f6; }
-    
+
+    .score-critical { background: var(--accent2); }
+    .score-high { background: var(--accent2); }
+    .score-medium { background: var(--accent4); }
+    .score-low { background: var(--accent); }
+
     .attack-type-badge {
         padding: 0.25rem 0.75rem;
         border-radius: 20px;
+        font-family: var(--font-mono);
         font-size: 0.8rem;
         font-weight: 500;
-        background: #e0e7ff;
-        color: #4c1d95;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent3);
     }
     
     .site-details {
@@ -283,28 +297,29 @@
         display: flex;
         gap: 1rem;
         margin-bottom: 1.5rem;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--border);
     }
-    
+
     .detail-tab {
         padding: 0.5rem 1rem;
         border: none;
         background: none;
-        color: var(--text-light);
+        color: var(--muted);
+        font-family: var(--font-mono);
         font-weight: 500;
         cursor: pointer;
         position: relative;
-        transition: color 0.2s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .detail-tab:hover {
-        color: var(--text-color);
+        color: var(--text);
     }
-    
+
     .detail-tab.active {
-        color: #0e7490;
+        color: var(--accent);
     }
-    
+
     .detail-tab.active::after {
         content: '';
         position: absolute;
@@ -312,7 +327,7 @@
         left: 0;
         right: 0;
         height: 2px;
-        background: #0e7490;
+        background: var(--accent);
     }
     
     .tab-content {
@@ -332,132 +347,152 @@
         font-size: 1.1rem;
         font-weight: 600;
         margin-bottom: 1rem;
-        color: var(--text-color);
+        color: var(--text);
         display: flex;
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .indicator-count {
-        background: #e0e7ff;
-        color: #4c1d95;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent3);
         padding: 0.125rem 0.5rem;
         border-radius: 12px;
+        font-family: var(--font-mono);
         font-size: 0.8rem;
         font-weight: 500;
     }
-    
+
     .indicator-list {
-        background: #f9fafb;
-        border-radius: 8px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 1rem;
-        font-family: monospace;
+        font-family: var(--font-mono);
         font-size: 0.85rem;
         max-height: 300px;
         overflow-y: auto;
     }
-    
+
     .indicator-item {
         padding: 0.5rem;
         margin-bottom: 0.5rem;
-        background: white;
-        border-radius: 4px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        color: var(--text-soft);
         word-break: break-all;
     }
-    
+
     .code-block {
-        background: #1e293b;
-        color: #e2e8f0;
+        background: #05050a;
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
+        color: var(--text-soft);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         overflow-x: auto;
-        font-family: monospace;
+        font-family: var(--font-mono);
         font-size: 0.85rem;
         position: relative;
         margin-bottom: 1rem;
     }
-    
+
     .copy-btn {
         position: absolute;
         top: 0.5rem;
         right: 0.5rem;
-        background: rgba(255,255,255,0.1);
-        border: 1px solid rgba(255,255,255,0.2);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent);
         padding: 0.25rem 0.75rem;
-        border-radius: 4px;
+        border-radius: var(--border-radius);
+        font-family: var(--font-mono);
         font-size: 0.75rem;
         cursor: pointer;
-        transition: background 0.2s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .copy-btn:hover {
-        background: rgba(255,255,255,0.2);
+        background: var(--surface);
+        border-color: var(--accent);
     }
-    
+
     /* Analysis Section */
     .analysis-section {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+        box-shadow: var(--shadow);
     }
-    
+
     .analysis-content {
         line-height: 1.8;
-        color: var(--text-color);
+        color: var(--text-soft);
     }
-    
+
     .analysis-content h2 {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        color: #0e7490;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 2rem 0 1rem;
         padding-bottom: 0.5rem;
-        border-bottom: 2px solid #e0e7ff;
+        border-bottom: 1px solid var(--border);
     }
-    
+
     .analysis-content h3 {
         font-size: 1.25rem;
-        color: var(--text-color);
+        color: var(--text);
         margin: 1.5rem 0 1rem;
     }
-    
+
     .analysis-content pre {
-        background: #f9fafb;
-        border: 1px solid #e5e7eb;
-        border-radius: 8px;
+        background: #05050a;
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
+        border-radius: var(--border-radius);
         padding: 1rem;
         overflow-x: auto;
         margin: 1rem 0;
+        font-family: var(--font-mono);
+        color: var(--text-soft);
     }
-    
+
     .analysis-content code {
-        background: #f3f4f6;
+        background: var(--surface-3);
+        color: var(--accent3);
         padding: 0.125rem 0.25rem;
         border-radius: 3px;
+        font-family: var(--font-mono);
         font-size: 0.9em;
     }
-    
+
     .analysis-content table {
         width: 100%;
         border-collapse: collapse;
         margin: 1rem 0;
     }
-    
+
     .analysis-content th,
     .analysis-content td {
         padding: 0.75rem;
         text-align: left;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--border);
     }
-    
+
     .analysis-content th {
-        background: #f9fafb;
+        background: var(--surface-2);
+        color: var(--accent);
         font-weight: 600;
+        border-bottom: 2px solid var(--accent);
     }
-    
+
     .analysis-content tr:hover {
-        background: #f9fafb;
+        background: var(--highlight);
     }
     
     /* Responsive */
@@ -485,7 +520,7 @@
     .empty-state {
         text-align: center;
         padding: 3rem;
-        color: var(--text-light);
+        color: var(--muted);
     }
     
     .empty-icon {
@@ -535,7 +570,7 @@
 <!-- Download Section -->
 <div style="display: flex; gap: 1rem; margin-bottom: 2rem; flex-wrap: wrap;">
     <a href="https://github.com/MHaggis/ClickGrab/tree/main/nightly_reports" 
-       class="action-btn" style="text-decoration: none; background: #0e7490; color: white; padding: 0.75rem 1.5rem;" target="_blank">
+       class="action-btn" style="text-decoration: none; background: var(--accent); border-color: var(--accent); color: var(--bg); padding: 0.75rem 1.5rem;" target="_blank">
         ⬇️ Download JSON Report
     </a>
     <a href="https://github.com/MHaggis/ClickGrab/tree/main/nightly_reports" 
@@ -591,29 +626,29 @@
     </div>
     
     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin-bottom: 2rem;">
-        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-            <div style="font-size: 1.5rem; font-weight: 700; color: #dc2626;">17</div>
-            <div style="font-size: 0.9rem; color: var(--text-light);">High Risk Commands</div>
+        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent2);">17</div>
+            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">High Risk Commands</div>
         </div>
-        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-            <div style="font-size: 1.5rem; font-weight: 700; color: #f59e0b;">569</div>
-            <div style="font-size: 0.9rem; color: var(--text-light);">Base64 Encoded</div>
+        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent4);">569</div>
+            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">Base64 Encoded</div>
         </div>
-        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-            <div style="font-size: 1.5rem; font-weight: 700; color: #8b5cf6;">0</div>
-            <div style="font-size: 0.9rem; color: var(--text-light);">Obfuscated JS</div>
+        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent3);">0</div>
+            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">Obfuscated JS</div>
         </div>
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.5rem; font-weight: 700; color: #3b82f6;">47</div>
-                            <div style="font-size: 0.9rem; color: var(--text-light);">Inline JS Redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent3);">47</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">Inline JS Redirects</div>
                         </div>
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                        <div style="font-size: 1.5rem; font-weight: 700; color: #ec4899;">9</div>
-                            <div style="font-size: 0.9rem; color: var(--text-light);">External JS Chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                        <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent2);">9</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">External JS Chains</div>
                         </div>
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.5rem; font-weight: 700; color: #22c55e;">40</div>
-                            <div style="font-size: 0.9rem; color: var(--text-light);">Redirect Follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent);">40</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">Redirect Follows</div>
                         </div>
     </div>
 
@@ -676,35 +711,35 @@
         <h3 style="margin:0 0 .5rem 0;">Top Indicators/Keywords</h3>
         <div style="display:flex; gap:.5rem; flex-wrap:wrap;">
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">robot (8)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">robot (8)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">hidden (7)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">hidden (7)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Robot (6)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Robot (6)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">CAPTCHA Verification (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">CAPTCHA Verification (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Verification ID (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Verification ID (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Ray ID (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Ray ID (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">I am not a robot (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">I am not a robot (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">You will observe (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">You will observe (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">CAPTCHA (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">CAPTCHA (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">CAPTCHA-verificatie-ID (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">CAPTCHA-verificatie-ID (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Verification (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Verification (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">verification (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">verification (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">verification-id (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">verification-id (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Checking if you are human (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Checking if you are human (5)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Verify you are human (5)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Verify you are human (5)</span>
             
         </div>
     </div>
@@ -714,8 +749,8 @@
 <!-- Detailed Site Analysis -->
 <section class="sites-section">
     <div class="sites-header">
-        <h2 style="font-size: 1.75rem; font-weight: 600;">Malicious Sites Detected</h2>
-        <span style="color: var(--text-light);">Click on a site to view detailed analysis</span>
+        <h2 style="font-family: var(--font-display); font-size: 1.75rem; font-weight: 400; letter-spacing: 1px; color: var(--text);">Malicious Sites Detected</h2>
+        <span style="font-family: var(--font-mono); color: var(--muted);">Click on a site to view detailed analysis</span>
     </div>
     
     
@@ -725,7 +760,7 @@
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://picsera.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             2129 indicators detected
                         </div>
                     </div>
@@ -754,29 +789,29 @@
                 <div id="overview-1" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">9</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">9</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">8</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">8</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -834,7 +869,7 @@
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 1 of 1 entries (truncated for performance)
                         </p>
                         
@@ -922,7 +957,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://www.bharatnamkeens.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             1563 indicators detected
                         </div>
                     </div>
@@ -947,19 +982,19 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div id="overview-2" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">19</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">19</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1032,7 +1067,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://94.130.229.174/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             590 indicators detected
                         </div>
                     </div>
@@ -1059,29 +1094,29 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div id="overview-3" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect chains</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1143,7 +1178,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 1 of 1 chains (truncated for performance)
                         </p>
                         
@@ -1192,7 +1227,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://74.50.99.45:8443/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             2374 indicators detected
                         </div>
                     </div>
@@ -1221,29 +1256,29 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div id="overview-4" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">6</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">6</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">captcha</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">captcha</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">223</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">223</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">22</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">22</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">high risk</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">high risk</div>
                         </div>
                         
                     </div>
@@ -1313,7 +1348,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 6 entries (truncated for performance)
                         </p>
                         
@@ -1344,7 +1379,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://fudgeshop.com.au</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             686 indicators detected
                         </div>
                     </div>
@@ -1371,29 +1406,29 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div id="overview-5" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">18</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">18</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect chains</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1453,7 +1488,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 3 chains (truncated for performance)
                         </p>
                         
@@ -1588,7 +1623,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://44.208.147.17/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             543 indicators detected
                         </div>
                     </div>
@@ -1613,19 +1648,19 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div id="overview-6" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">7</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">7</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1694,7 +1729,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://capazmente.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             353 indicators detected
                         </div>
                     </div>
@@ -1721,24 +1756,24 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div id="overview-7" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">9</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">9</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">8</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">8</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1804,7 +1839,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 1 of 1 entries (truncated for performance)
                         </p>
                         
@@ -1830,7 +1865,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://98.70.13.131/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             801 indicators detected
                         </div>
                     </div>
@@ -1857,29 +1892,29 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div id="overview-8" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">35</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">35</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect chains</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">6</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">6</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1939,7 +1974,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 2 chains (truncated for performance)
                         </p>
                         
@@ -2105,7 +2140,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://creatorssky.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             388 indicators detected
                         </div>
                     </div>
@@ -2132,19 +2167,19 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div id="overview-9" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">7</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">7</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2208,7 +2243,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 1 of 1 entries (truncated for performance)
                         </p>
                         
@@ -2234,7 +2269,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://5.63.157.201/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             98 indicators detected
                         </div>
                     </div>
@@ -2261,24 +2296,24 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div id="overview-10" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2380,7 +2415,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://senevie.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             300 indicators detected
                         </div>
                     </div>
@@ -2405,19 +2440,19 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-11" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">39</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">39</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">6</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">6</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2492,7 +2527,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://www.scillarodriguez.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             281 indicators detected
                         </div>
                     </div>
@@ -2517,19 +2552,19 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-12" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2598,7 +2633,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://www.dorper.com.au</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             229 indicators detected
                         </div>
                     </div>
@@ -2625,29 +2660,29 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-13" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">26</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">26</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect chains</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2711,7 +2746,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 1 of 1 chains (truncated for performance)
                         </p>
                         
@@ -2772,7 +2807,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://evodigital.com.au</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             264 indicators detected
                         </div>
                     </div>
@@ -2799,24 +2834,24 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-14" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">37</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">37</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">7</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">7</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2937,7 +2972,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://www.maheshwaree.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             244 indicators detected
                         </div>
                     </div>
@@ -2962,14 +2997,14 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-15" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">23</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">23</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -3040,7 +3075,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://maheshwaree.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             244 indicators detected
                         </div>
                     </div>
@@ -3065,14 +3100,14 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-16" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">23</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">23</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -3143,7 +3178,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://revistadiversidadcultural.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             122 indicators detected
                         </div>
                     </div>
@@ -3170,29 +3205,29 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-17" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect chains</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -3252,7 +3287,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 2 chains (truncated for performance)
                         </p>
                         
@@ -3374,7 +3409,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://173.231.196.249/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             79 indicators detected
                         </div>
                     </div>
@@ -3403,34 +3438,34 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-18" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">powershell</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">powershell</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">6</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">6</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">captcha</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">captcha</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">27</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">27</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">high risk</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">high risk</div>
                         </div>
                         
                     </div>
@@ -3514,7 +3549,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 6 entries (truncated for performance)
                         </p>
                         
@@ -3545,7 +3580,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://103.74.5.124/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             74 indicators detected
                         </div>
                     </div>
@@ -3574,29 +3609,29 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-19" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">powershell</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">powershell</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">6</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">6</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">captcha</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">captcha</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">22</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">22</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -3678,7 +3713,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 6 entries (truncated for performance)
                         </p>
                         
@@ -3709,7 +3744,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">http://103.241.42.40/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             68 indicators detected
                         </div>
                     </div>
@@ -3738,24 +3773,24 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-20" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">6</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">6</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">captcha</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">captcha</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">19</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">19</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -3825,7 +3860,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 6 entries (truncated for performance)
                         </p>
                         
@@ -3853,7 +3888,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
         
         
         
-        <div style="text-align: center; padding: 2rem; color: var(--text-light);">
+        <div style="text-align: center; padding: 2rem; font-family: var(--font-mono); color: var(--muted);">
             <p>Showing top 20 malicious sites. 18 additional sites detected.</p>
         </div>
         

--- a/public/reports/2026-05-31.html
+++ b/public/reports/2026-05-31.html
@@ -5,28 +5,28 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ClickGrab Report - May 31, 2026</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <style>
     /* Report Header */
     .report-hero {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         position: relative;
         overflow: hidden;
+        box-shadow: var(--shadow);
     }
-    
+
     .report-hero::before {
         content: '';
         position: absolute;
@@ -34,27 +34,31 @@
         left: 0;
         right: 0;
         bottom: 0;
-        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><pattern id="grid" width="10" height="10" patternUnits="userSpaceOnUse"><path d="M 10 0 L 0 0 0 10" fill="none" stroke="rgba(255,255,255,0.1)" stroke-width="0.5"/></pattern><rect width="100" height="100" fill="url(%23grid)"/></svg>');
-        opacity: 0.3;
+        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><pattern id="grid" width="10" height="10" patternUnits="userSpaceOnUse"><path d="M 10 0 L 0 0 0 10" fill="none" stroke="rgba(0,255,136,0.06)" stroke-width="0.5"/></pattern><rect width="100" height="100" fill="url(%23grid)"/></svg>');
+        opacity: 0.5;
     }
-    
+
     .report-hero-content {
         position: relative;
         z-index: 1;
     }
-    
+
     .report-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 700;
+        font-weight: 400;
+        letter-spacing: 2px;
+        color: var(--accent);
         margin-bottom: 1rem;
     }
-    
+
     .report-meta {
         display: flex;
         gap: 2rem;
         flex-wrap: wrap;
-        font-size: 1.1rem;
-        opacity: 0.95;
+        font-family: var(--font-mono);
+        font-size: 0.95rem;
+        color: var(--text-soft);
     }
     
     /* Summary Cards */
@@ -66,78 +70,82 @@
     }
     
     .summary-card {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 1.5rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+        box-shadow: var(--shadow);
         text-align: center;
-        transition: transform 0.3s ease;
-        border: 1px solid #e5e7eb;
+        transition: transform 0.18s ease, border-color 0.18s ease;
+        border: 1px solid var(--border);
         position: relative;
         overflow: hidden;
     }
-    
+
     .summary-card::before {
         content: '';
         position: absolute;
         top: 0;
         left: 0;
         right: 0;
-        height: 4px;
-        background: linear-gradient(90deg, var(--gradient-start), var(--gradient-end));
+        height: 3px;
+        background: var(--accent-edge, var(--accent));
     }
-    
-    .summary-card.total { --gradient-start: #0e7490; --gradient-end: #0f766e; }
-    .summary-card.threats { --gradient-start: #22c55e; --gradient-end: #0891b2; }
-    .summary-card.powershell { --gradient-start: #4facfe; --gradient-end: #00f2fe; }
-    .summary-card.clipboard { --gradient-start: #fa709a; --gradient-end: #fee140; }
-    .summary-card.score { --gradient-start: #30cfd0; --gradient-end: #330867; }
-    
+
+    .summary-card.total { --accent-edge: var(--accent3); }
+    .summary-card.threats { --accent-edge: var(--accent2); }
+    .summary-card.powershell { --accent-edge: var(--accent3); }
+    .summary-card.clipboard { --accent-edge: var(--accent4); }
+    .summary-card.score { --accent-edge: var(--accent); }
+
     .summary-card:hover {
-        transform: translateY(-5px);
-        box-shadow: 0 8px 30px rgba(0,0,0,0.12);
+        transform: translateY(-2px);
+        border-color: var(--accent);
     }
-    
+
     .summary-icon {
         font-size: 2.5rem;
         margin-bottom: 1rem;
     }
-    
+
     .summary-value {
+        font-family: var(--font-mono);
         font-size: 2.5rem;
         font-weight: 700;
-        color: var(--text-color);
+        color: var(--text);
         margin-bottom: 0.5rem;
     }
-    
+
     .summary-label {
-        color: var(--text-light);
+        font-family: var(--font-mono);
+        color: var(--muted);
         font-size: 0.9rem;
         text-transform: uppercase;
         letter-spacing: 0.5px;
     }
-    
+
     .summary-change {
         margin-top: 0.5rem;
+        font-family: var(--font-mono);
         font-size: 0.85rem;
         display: flex;
         align-items: center;
         justify-content: center;
         gap: 0.25rem;
     }
-    
-    .change-up { color: #ef4444; }
-    .change-down { color: #22c55e; }
+
+    .change-up { color: var(--accent2); }
+    .change-down { color: var(--accent); }
     
     /* Threat Overview */
     .threat-overview {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
         margin-bottom: 3rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+        box-shadow: var(--shadow);
     }
-    
+
     .threat-header {
         display: flex;
         justify-content: space-between;
@@ -146,33 +154,36 @@
         flex-wrap: wrap;
         gap: 1rem;
     }
-    
+
     .threat-title {
+        font-family: var(--font-display);
         font-size: 1.75rem;
-        font-weight: 600;
-        color: var(--text-color);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
     }
-    
+
     .threat-actions {
         display: flex;
         gap: 1rem;
     }
-    
+
     .action-btn {
         padding: 0.5rem 1rem;
-        border: 1px solid #e5e7eb;
-        border-radius: 8px;
-        background: white;
-        color: var(--text-color);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        background: var(--surface-2);
+        color: var(--text-soft);
+        font-family: var(--font-mono);
         font-size: 0.9rem;
         cursor: pointer;
-        transition: all 0.2s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .action-btn:hover {
-        background: #f9fafb;
-        border-color: #0e7490;
-        color: #0e7490;
+        background: var(--surface-3);
+        border-color: var(--accent);
+        color: var(--accent);
     }
 
     /* Simple bar chart styles */
@@ -183,14 +194,14 @@
         margin-top: 1rem;
     }
     .bar {
-        background: #f9fafb;
-        border: 1px solid #e5e7eb;
-        border-radius: 8px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 0.75rem;
     }
-    .bar-label { font-size: 0.9rem; color: var(--text-light); }
-    .bar-track { height: 10px; background: #eef2ff; border-radius: 6px; margin-top: 0.5rem; overflow: hidden; }
-    .bar-fill { height: 100%; background: linear-gradient(90deg,#0e7490,#0f766e); border-radius: 6px; width: 0%; transition: width .6s ease; }
+    .bar-label { font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted); }
+    .bar-track { height: 10px; background: var(--surface-3); border-radius: 6px; margin-top: 0.5rem; overflow: hidden; }
+    .bar-fill { height: 100%; background: var(--accent); border-radius: 6px; width: 0%; transition: width .6s ease; }
     
     /* Site Analysis Cards */
     .sites-section {
@@ -205,27 +216,27 @@
     }
     
     .site-card {
-        background: white;
-        border-radius: 12px;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.08);
+        background: var(--surface);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
         margin-bottom: 1.5rem;
         overflow: hidden;
-        transition: all 0.3s ease;
-        border: 1px solid #e5e7eb;
+        transition: all 0.18s ease;
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
     }
-    
+
     .site-card:hover {
-        box-shadow: 0 4px 20px rgba(0,0,0,0.12);
-        border-color: #0e7490;
+        border-color: var(--accent);
     }
-    
+
     .site-header {
-        background: #f9fafb;
+        background: var(--surface-2);
         padding: 1.5rem;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--border);
         cursor: pointer;
     }
-    
+
     .site-header-content {
         display: flex;
         justify-content: space-between;
@@ -233,41 +244,44 @@
         flex-wrap: wrap;
         gap: 1rem;
     }
-    
+
     .site-url {
         font-weight: 600;
-        color: #ef4444;
+        color: var(--accent2);
         word-break: break-all;
-        font-family: monospace;
+        font-family: var(--font-mono);
         font-size: 0.95rem;
     }
-    
+
     .site-badges {
         display: flex;
         gap: 0.5rem;
         flex-wrap: wrap;
     }
-    
+
     .threat-score-badge {
         padding: 0.25rem 0.75rem;
         border-radius: 20px;
+        font-family: var(--font-mono);
         font-size: 0.8rem;
         font-weight: 600;
-        color: white;
+        color: var(--bg);
     }
-    
-    .score-critical { background: #dc2626; }
-    .score-high { background: #ef4444; }
-    .score-medium { background: #f59e0b; }
-    .score-low { background: #3b82f6; }
-    
+
+    .score-critical { background: var(--accent2); }
+    .score-high { background: var(--accent2); }
+    .score-medium { background: var(--accent4); }
+    .score-low { background: var(--accent); }
+
     .attack-type-badge {
         padding: 0.25rem 0.75rem;
         border-radius: 20px;
+        font-family: var(--font-mono);
         font-size: 0.8rem;
         font-weight: 500;
-        background: #e0e7ff;
-        color: #4c1d95;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent3);
     }
     
     .site-details {
@@ -283,28 +297,29 @@
         display: flex;
         gap: 1rem;
         margin-bottom: 1.5rem;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--border);
     }
-    
+
     .detail-tab {
         padding: 0.5rem 1rem;
         border: none;
         background: none;
-        color: var(--text-light);
+        color: var(--muted);
+        font-family: var(--font-mono);
         font-weight: 500;
         cursor: pointer;
         position: relative;
-        transition: color 0.2s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .detail-tab:hover {
-        color: var(--text-color);
+        color: var(--text);
     }
-    
+
     .detail-tab.active {
-        color: #0e7490;
+        color: var(--accent);
     }
-    
+
     .detail-tab.active::after {
         content: '';
         position: absolute;
@@ -312,7 +327,7 @@
         left: 0;
         right: 0;
         height: 2px;
-        background: #0e7490;
+        background: var(--accent);
     }
     
     .tab-content {
@@ -332,132 +347,152 @@
         font-size: 1.1rem;
         font-weight: 600;
         margin-bottom: 1rem;
-        color: var(--text-color);
+        color: var(--text);
         display: flex;
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .indicator-count {
-        background: #e0e7ff;
-        color: #4c1d95;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent3);
         padding: 0.125rem 0.5rem;
         border-radius: 12px;
+        font-family: var(--font-mono);
         font-size: 0.8rem;
         font-weight: 500;
     }
-    
+
     .indicator-list {
-        background: #f9fafb;
-        border-radius: 8px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 1rem;
-        font-family: monospace;
+        font-family: var(--font-mono);
         font-size: 0.85rem;
         max-height: 300px;
         overflow-y: auto;
     }
-    
+
     .indicator-item {
         padding: 0.5rem;
         margin-bottom: 0.5rem;
-        background: white;
-        border-radius: 4px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        color: var(--text-soft);
         word-break: break-all;
     }
-    
+
     .code-block {
-        background: #1e293b;
-        color: #e2e8f0;
+        background: #05050a;
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
+        color: var(--text-soft);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         overflow-x: auto;
-        font-family: monospace;
+        font-family: var(--font-mono);
         font-size: 0.85rem;
         position: relative;
         margin-bottom: 1rem;
     }
-    
+
     .copy-btn {
         position: absolute;
         top: 0.5rem;
         right: 0.5rem;
-        background: rgba(255,255,255,0.1);
-        border: 1px solid rgba(255,255,255,0.2);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent);
         padding: 0.25rem 0.75rem;
-        border-radius: 4px;
+        border-radius: var(--border-radius);
+        font-family: var(--font-mono);
         font-size: 0.75rem;
         cursor: pointer;
-        transition: background 0.2s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .copy-btn:hover {
-        background: rgba(255,255,255,0.2);
+        background: var(--surface);
+        border-color: var(--accent);
     }
-    
+
     /* Analysis Section */
     .analysis-section {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+        box-shadow: var(--shadow);
     }
-    
+
     .analysis-content {
         line-height: 1.8;
-        color: var(--text-color);
+        color: var(--text-soft);
     }
-    
+
     .analysis-content h2 {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        color: #0e7490;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 2rem 0 1rem;
         padding-bottom: 0.5rem;
-        border-bottom: 2px solid #e0e7ff;
+        border-bottom: 1px solid var(--border);
     }
-    
+
     .analysis-content h3 {
         font-size: 1.25rem;
-        color: var(--text-color);
+        color: var(--text);
         margin: 1.5rem 0 1rem;
     }
-    
+
     .analysis-content pre {
-        background: #f9fafb;
-        border: 1px solid #e5e7eb;
-        border-radius: 8px;
+        background: #05050a;
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
+        border-radius: var(--border-radius);
         padding: 1rem;
         overflow-x: auto;
         margin: 1rem 0;
+        font-family: var(--font-mono);
+        color: var(--text-soft);
     }
-    
+
     .analysis-content code {
-        background: #f3f4f6;
+        background: var(--surface-3);
+        color: var(--accent3);
         padding: 0.125rem 0.25rem;
         border-radius: 3px;
+        font-family: var(--font-mono);
         font-size: 0.9em;
     }
-    
+
     .analysis-content table {
         width: 100%;
         border-collapse: collapse;
         margin: 1rem 0;
     }
-    
+
     .analysis-content th,
     .analysis-content td {
         padding: 0.75rem;
         text-align: left;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--border);
     }
-    
+
     .analysis-content th {
-        background: #f9fafb;
+        background: var(--surface-2);
+        color: var(--accent);
         font-weight: 600;
+        border-bottom: 2px solid var(--accent);
     }
-    
+
     .analysis-content tr:hover {
-        background: #f9fafb;
+        background: var(--highlight);
     }
     
     /* Responsive */
@@ -485,7 +520,7 @@
     .empty-state {
         text-align: center;
         padding: 3rem;
-        color: var(--text-light);
+        color: var(--muted);
     }
     
     .empty-icon {
@@ -535,7 +570,7 @@
 <!-- Download Section -->
 <div style="display: flex; gap: 1rem; margin-bottom: 2rem; flex-wrap: wrap;">
     <a href="https://github.com/MHaggis/ClickGrab/tree/main/nightly_reports" 
-       class="action-btn" style="text-decoration: none; background: #0e7490; color: white; padding: 0.75rem 1.5rem;" target="_blank">
+       class="action-btn" style="text-decoration: none; background: var(--accent); border-color: var(--accent); color: var(--bg); padding: 0.75rem 1.5rem;" target="_blank">
         ⬇️ Download JSON Report
     </a>
     <a href="https://github.com/MHaggis/ClickGrab/tree/main/nightly_reports" 
@@ -591,29 +626,29 @@
     </div>
     
     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin-bottom: 2rem;">
-        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-            <div style="font-size: 1.5rem; font-weight: 700; color: #dc2626;">17</div>
-            <div style="font-size: 0.9rem; color: var(--text-light);">High Risk Commands</div>
+        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent2);">17</div>
+            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">High Risk Commands</div>
         </div>
-        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-            <div style="font-size: 1.5rem; font-weight: 700; color: #f59e0b;">598</div>
-            <div style="font-size: 0.9rem; color: var(--text-light);">Base64 Encoded</div>
+        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent4);">598</div>
+            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">Base64 Encoded</div>
         </div>
-        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-            <div style="font-size: 1.5rem; font-weight: 700; color: #8b5cf6;">0</div>
-            <div style="font-size: 0.9rem; color: var(--text-light);">Obfuscated JS</div>
+        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent3);">0</div>
+            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">Obfuscated JS</div>
         </div>
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.5rem; font-weight: 700; color: #3b82f6;">46</div>
-                            <div style="font-size: 0.9rem; color: var(--text-light);">Inline JS Redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent3);">46</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">Inline JS Redirects</div>
                         </div>
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                        <div style="font-size: 1.5rem; font-weight: 700; color: #ec4899;">10</div>
-                            <div style="font-size: 0.9rem; color: var(--text-light);">External JS Chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                        <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent2);">10</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">External JS Chains</div>
                         </div>
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.5rem; font-weight: 700; color: #22c55e;">38</div>
-                            <div style="font-size: 0.9rem; color: var(--text-light);">Redirect Follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent);">38</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">Redirect Follows</div>
                         </div>
     </div>
 
@@ -676,35 +711,35 @@
         <h3 style="margin:0 0 .5rem 0;">Top Indicators/Keywords</h3>
         <div style="display:flex; gap:.5rem; flex-wrap:wrap;">
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">robot (9)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">robot (9)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">hidden (8)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">hidden (8)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Robot (6)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Robot (6)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">CAPTCHA Verification (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">CAPTCHA Verification (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Verification ID (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Verification ID (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Ray ID (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Ray ID (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">I am not a robot (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">I am not a robot (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">You will observe (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">You will observe (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">CAPTCHA (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">CAPTCHA (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">CAPTCHA-verificatie-ID (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">CAPTCHA-verificatie-ID (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Verification (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Verification (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">verification (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">verification (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">verification-id (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">verification-id (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Checking if you are human (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Checking if you are human (4)</span>
             
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">Verify you are human (4)</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">Verify you are human (4)</span>
             
         </div>
     </div>
@@ -714,8 +749,8 @@
 <!-- Detailed Site Analysis -->
 <section class="sites-section">
     <div class="sites-header">
-        <h2 style="font-size: 1.75rem; font-weight: 600;">Malicious Sites Detected</h2>
-        <span style="color: var(--text-light);">Click on a site to view detailed analysis</span>
+        <h2 style="font-family: var(--font-display); font-size: 1.75rem; font-weight: 400; letter-spacing: 1px; color: var(--text);">Malicious Sites Detected</h2>
+        <span style="font-family: var(--font-mono); color: var(--muted);">Click on a site to view detailed analysis</span>
     </div>
     
     
@@ -725,7 +760,7 @@
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://picsera.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             2128 indicators detected
                         </div>
                     </div>
@@ -754,29 +789,29 @@
                 <div id="overview-1" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">9</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">9</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">8</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">8</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -834,7 +869,7 @@
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 1 of 1 entries (truncated for performance)
                         </p>
                         
@@ -922,7 +957,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://www.bharatnamkeens.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             1566 indicators detected
                         </div>
                     </div>
@@ -947,19 +982,19 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div id="overview-2" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">19</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">19</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1032,7 +1067,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">http://192.155.93.247:3101/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             1025 indicators detected
                         </div>
                     </div>
@@ -1057,14 +1092,14 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div id="overview-3" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">6</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">6</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1133,7 +1168,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://104.199.248.167/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             705 indicators detected
                         </div>
                     </div>
@@ -1158,14 +1193,14 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div id="overview-4" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1234,7 +1269,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://74.50.99.45:8443/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             2618 indicators detected
                         </div>
                     </div>
@@ -1263,29 +1298,29 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div id="overview-5" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">6</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">6</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">captcha</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">captcha</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">244</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">244</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">22</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">22</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">high risk</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">high risk</div>
                         </div>
                         
                     </div>
@@ -1355,7 +1390,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 6 entries (truncated for performance)
                         </p>
                         
@@ -1386,7 +1421,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://94.130.229.174/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             590 indicators detected
                         </div>
                     </div>
@@ -1413,29 +1448,29 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div id="overview-6" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect chains</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1497,7 +1532,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 1 of 1 chains (truncated for performance)
                         </p>
                         
@@ -1546,7 +1581,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://fudgeshop.com.au</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             686 indicators detected
                         </div>
                     </div>
@@ -1573,29 +1608,29 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                 <div id="overview-7" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">18</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">18</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect chains</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1655,7 +1690,7 @@ j=d.createElement(s),dl=l!=&#39;dataLayer&#39;?&#39;&amp;l=&#39;+l:&#39;&#39;;j.
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 3 chains (truncated for performance)
                         </p>
                         
@@ -1790,7 +1825,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://44.208.147.17/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             543 indicators detected
                         </div>
                     </div>
@@ -1815,19 +1850,19 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div id="overview-8" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">7</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">7</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -1896,7 +1931,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://capazmente.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             353 indicators detected
                         </div>
                     </div>
@@ -1923,24 +1958,24 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div id="overview-9" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">9</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">9</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">8</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">8</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2006,7 +2041,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 1 of 1 entries (truncated for performance)
                         </p>
                         
@@ -2032,7 +2067,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://98.70.13.131/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             799 indicators detected
                         </div>
                     </div>
@@ -2059,29 +2094,29 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div id="overview-10" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">35</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">35</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect chains</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">6</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">6</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2141,7 +2176,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 2 chains (truncated for performance)
                         </p>
                         
@@ -2307,7 +2342,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://creatorssky.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             388 indicators detected
                         </div>
                     </div>
@@ -2334,19 +2369,19 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div id="overview-11" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">clipboard</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">clipboard</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">7</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">7</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2410,7 +2445,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 1 of 1 entries (truncated for performance)
                         </p>
                         
@@ -2436,7 +2471,7 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://5.63.157.201/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             95 indicators detected
                         </div>
                     </div>
@@ -2463,24 +2498,24 @@ if(!YT.loading){YT.loading=1;(function(){var l=[];YT.ready=function(f){if(YT.loa
                 <div id="overview-12" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2582,7 +2617,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://senevie.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             300 indicators detected
                         </div>
                     </div>
@@ -2607,19 +2642,19 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-13" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">39</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">39</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">6</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">6</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2694,7 +2729,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://www.scillarodriguez.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             282 indicators detected
                         </div>
                     </div>
@@ -2719,19 +2754,19 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-14" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2800,7 +2835,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://www.dorper.com.au</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             229 indicators detected
                         </div>
                     </div>
@@ -2827,29 +2862,29 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-15" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">26</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">26</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect chains</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -2913,7 +2948,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 1 of 1 chains (truncated for performance)
                         </p>
                         
@@ -2974,7 +3009,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://evodigital.com.au</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             264 indicators detected
                         </div>
                     </div>
@@ -3001,24 +3036,24 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-16" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">37</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">37</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">7</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">7</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -3139,7 +3174,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://www.maheshwaree.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             244 indicators detected
                         </div>
                     </div>
@@ -3164,14 +3199,14 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-17" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">23</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">23</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -3242,7 +3277,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://maheshwaree.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             244 indicators detected
                         </div>
                     </div>
@@ -3267,14 +3302,14 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-18" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">23</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">23</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -3345,7 +3380,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">http://172.96.189.153/</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             265 indicators detected
                         </div>
                     </div>
@@ -3374,29 +3409,29 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-19" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">captcha</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">captcha</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">14</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">14</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -3516,7 +3551,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">https://revistadiversidadcultural.com</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             122 indicators detected
                         </div>
                     </div>
@@ -3543,29 +3578,29 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                 <div id="overview-20" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">5</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">base64</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">5</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">base64</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">1</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">1</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirects</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">2</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">2</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect chains</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">4</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">redirect follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">4</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">redirect follows</div>
                         </div>
                         
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">3</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">suspicious keywords</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">3</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">suspicious keywords</div>
                         </div>
                         
                     </div>
@@ -3625,7 +3660,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
                     
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first 2 of 2 chains (truncated for performance)
                         </p>
                         
@@ -3744,7 +3779,7 @@ function ca(a){a=[&#34;object&#34;==typeof globalThis&amp;&amp;globalThis,a,&#34
         
         
         
-        <div style="text-align: center; padding: 2rem; color: var(--text-light);">
+        <div style="text-align: center; padding: 2rem; font-family: var(--font-mono); color: var(--muted);">
             <p>Showing top 20 malicious sites. 22 additional sites detected.</p>
         </div>
         

--- a/public/techniques.html
+++ b/public/techniques.html
@@ -5,226 +5,251 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ClickFix Techniques - ClickGrab</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     /* ClickFix Wiki Styling */
     .techniques-header {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: linear-gradient(135deg, var(--surface-2) 0%, var(--surface-3) 100%);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        box-shadow: var(--shadow);
         margin-bottom: 3rem;
         text-align: center;
     }
-    
+
     .techniques-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        color: white;
+        color: var(--accent);
     }
-    
+
     .techniques-subtitle {
         font-size: 1.2rem;
-        color: white;
+        color: var(--text-soft);
         max-width: 600px;
         margin: 0 auto;
         line-height: 1.6;
     }
-    /* Enforce white for any nested text in header/subtitle against global styles */
-    .techniques-header,
-    .techniques-header *,
-    .techniques-title,
-    .techniques-subtitle {
-        color: #FFFFFF !important;
+    /* Keep header copy readable against the dark surface */
+    .techniques-header .techniques-subtitle,
+    .techniques-header .techniques-subtitle * {
+        color: var(--text-soft) !important;
     }
-    
+    .techniques-header .techniques-title {
+        color: var(--accent) !important;
+    }
+
     .search-section {
         margin-bottom: 2rem;
     }
-    
+
     .search-box {
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
-    
+
     .filter-section {
         margin-bottom: 3rem;
     }
-    
+
     .filter-groups {
         display: flex;
         gap: 2rem;
         flex-wrap: wrap;
         justify-content: center;
     }
-    
+
     .filter-group {
-        background: white;
+        background: var(--surface);
         padding: 1.5rem;
-        border-radius: 12px;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
         min-width: 200px;
     }
-    
+
     .filter-group-title {
+        font-family: var(--font-mono);
         font-weight: 600;
         margin-bottom: 1rem;
-        color: #333;
+        color: var(--accent);
         font-size: 0.9rem;
         text-transform: uppercase;
         letter-spacing: 1px;
     }
-    
+
     .filter-tags {
         display: flex;
         flex-direction: column;
         gap: 0.5rem;
     }
-    
+
     .filter-tag {
         padding: 0.5rem 1rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 25px;
+        background: var(--surface-2);
+        color: var(--text-soft);
         cursor: pointer;
-        transition: all 0.3s ease;
+        transition: all 0.18s ease;
         font-size: 0.9rem;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .filter-tag:hover {
-        border-color: #0e7490;
-        background: rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        background: var(--highlight);
+        color: var(--text);
     }
-    
+
     .filter-tag.active {
-        background: #0e7490;
-        color: white;
-        border-color: #0e7490;
+        background: var(--accent);
+        color: var(--bg);
+        border-color: var(--accent);
     }
-    
+
     .tools-list {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
         gap: 1.5rem;
         margin-bottom: 3rem;
     }
-    
+
     .tool-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 1.5rem;
         text-decoration: none;
-        color: inherit;
-        transition: all 0.3s ease;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border: 1px solid transparent;
+        color: var(--text);
+        transition: all 0.18s ease;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
         position: relative;
         overflow: hidden;
     }
-    
+
     .tool-item::before {
         content: '';
         position: absolute;
         top: 0;
         left: 0;
         right: 0;
-        height: 4px;
-        background: linear-gradient(90deg, #0e7490, #0f766e);
+        height: 3px;
+        background: var(--accent);
         transform: scaleX(0);
-        transition: transform 0.3s ease;
+        transition: transform 0.18s ease;
     }
-    
+
     .tool-item:hover {
-        transform: translateY(-5px);
-        box-shadow: 0 8px 30px rgba(0,0,0,0.12);
-        border-color: #0e7490;
+        transform: translateY(-2px);
+        box-shadow: var(--shadow);
+        border-color: var(--accent);
     }
-    
+
     .tool-item:hover::before {
         transform: scaleX(1);
     }
-    
+
     .tool-title {
-        font-size: 1.25rem;
-        font-weight: 700;
+        font-family: var(--font-display);
+        font-size: 1.4rem;
+        font-weight: 400;
+        letter-spacing: 1px;
         margin-bottom: 1rem;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .tool-tags {
         display: flex;
         flex-wrap: wrap;
         gap: 0.5rem;
         margin-bottom: 1rem;
     }
-    
+
     .tool-tag {
         padding: 0.25rem 0.75rem;
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
     }
-    
+
     .tool-tag.platform-tag {
-        background: rgba(102, 126, 234, 0.1);
-        color: #0e7490;
+        background: rgba(61, 158, 255, 0.12);
+        color: var(--accent3);
+        border: 1px solid rgba(61, 158, 255, 0.25);
     }
-    
+
     .tool-tag.presentation-tag {
-        background: rgba(118, 75, 162, 0.1);
-        color: #0f766e;
+        background: var(--highlight);
+        color: var(--accent);
+        border: 1px solid rgba(0, 255, 136, 0.25);
     }
-    
+
     .tool-tag.capability-tag {
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: rgba(255, 204, 0, 0.12);
+        color: var(--accent4);
+        border: 1px solid rgba(255, 204, 0, 0.25);
     }
-    
+
     .tool-lure-count {
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         font-weight: 500;
     }
-    
+
     .no-results {
         text-align: center;
         padding: 3rem;
-        color: #666;
+        color: var(--muted);
     }
-    
+
     .no-results h3 {
+        font-family: var(--font-display);
         font-size: 1.5rem;
+        font-weight: 400;
+        letter-spacing: 1px;
         margin-bottom: 0.5rem;
-        color: #333;
+        color: var(--text);
     }
     
     
@@ -298,7 +323,7 @@
                     <i class="fab fa-windows" style="color: #0078d4;"></i> Windows
                 </div>
                 <div class="filter-tag" data-platform="Mac" onclick="toggleFilter('platform', 'Mac', this)">
-                    <i class="fab fa-apple" style="color: #000000;"></i> Mac
+                    <i class="fab fa-apple" style="color: var(--text);"></i> Mac
                 </div>
                 <div class="filter-tag" data-platform="Linux" onclick="toggleFilter('platform', 'Linux', this)">
                     <i class="fab fa-linux" style="color: #f47421;"></i> Linux
@@ -322,7 +347,7 @@
             <div class="filter-group-title">Capabilities</div>
             <div class="filter-tags" id="capabilityTags">
                 <div class="filter-tag" data-capability="UAC" onclick="toggleFilter('capability', 'UAC', this)">
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 </div>
                 <div class="filter-tag" data-capability="MOTW" onclick="toggleFilter('capability', 'MOTW', this)">
                     <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
@@ -337,6 +362,360 @@
 
 <!-- Tools Grid -->
 <div class="tools-list" id="toolsGrid">
+    
+    <a href="/ClickGrab/techniques/explorer-shell-uris.html" class="tool-item" data-id="explorer-shell-uris">
+        <div class="tool-title">explorer shell URIs</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">2 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/office-uri.html" class="tool-item" data-id="office-uri">
+        <div class="tool-title">Office URI schemes (ms-word/ms-excel)</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/msra.exe.html" class="tool-item" data-id="msra.exe">
+        <div class="tool-title">msra.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="MOTW">
+                
+                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/consentfix.html" class="tool-item" data-id="consentfix">
+        <div class="tool-title">ConsentFix</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="BROWSER">
+                
+                browser
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/colorcpl.exe.html" class="tool-item" data-id="colorcpl.exe">
+        <div class="tool-title">colorcpl.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="MOTW">
+                
+                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                
+            </span>
+            
+            <div class="tool-lure-count">2 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/dcomcnfg.exe.html" class="tool-item" data-id="dcomcnfg.exe">
+        <div class="tool-title">dcomcnfg.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/search-ms.html" class="tool-item" data-id="search-ms">
+        <div class="tool-title">search-ms protocol</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/taskmgr.exe.html" class="tool-item" data-id="taskmgr.exe">
+        <div class="tool-title">taskmgr.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/msiexec.exe.html" class="tool-item" data-id="msiexec.exe">
+        <div class="tool-title">msiexec.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="CLI">
+                
+                CLI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/powershell.exe.html" class="tool-item" data-id="powershell.exe">
+        <div class="tool-title">powershell.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="MOTW">
+                
+                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="UAC">
+                
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
+                
+            </span>
+            
+            <div class="tool-lure-count">2 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/wextract.exe.html" class="tool-item" data-id="wextract.exe">
+        <div class="tool-title">wextract.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="CLI">
+                
+                CLI
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">2 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/eventvwr.exe.html" class="tool-item" data-id="eventvwr.exe">
+        <div class="tool-title">eventvwr.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">2 lures</div>
+        </div>
+    </a>
     
     <a href="/ClickGrab/techniques/conhost.exe.html" class="tool-item" data-id="conhost.exe">
         <div class="tool-title">conhost.exe</div>
@@ -354,11 +733,107 @@
             
             <span class="tool-tag capability-tag" data-capability="UAC">
                 
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 
             </span>
             
             <div class="tool-lure-count">2 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/filefix.html" class="tool-item" data-id="filefix">
+        <div class="tool-title">FileFix (Explorer address bar)</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="CLI">
+                
+                CLI
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">3 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/certutil.exe.html" class="tool-item" data-id="certutil.exe">
+        <div class="tool-title">certutil.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="MOTW">
+                
+                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="UAC">
+                
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
+                
+            </span>
+            
+            <div class="tool-lure-count">2 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/crashfix.html" class="tool-item" data-id="crashfix">
+        <div class="tool-title">CrashFix</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="BROWSER">
+                
+                browser
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="CLI">
+                
+                CLI
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
         </div>
     </a>
     
@@ -422,252 +897,6 @@
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/osascript.html" class="tool-item" data-id="osascript">
-        <div class="tool-title">osascript</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Mac">
-                
-                mac
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="CLI">
-                
-                CLI
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="Credential Theft">
-                
-                Credential Theft
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="Data Exfiltration">
-                
-                Data Exfiltration
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/explorer-shell-uris.html" class="tool-item" data-id="explorer-shell-uris">
-        <div class="tool-title">explorer shell URIs</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">2 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/search-ms.html" class="tool-item" data-id="search-ms">
-        <div class="tool-title">search-ms protocol</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/office-uri.html" class="tool-item" data-id="office-uri">
-        <div class="tool-title">Office URI schemes (ms-word/ms-excel)</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/regasm.exe.html" class="tool-item" data-id="regasm.exe">
-        <div class="tool-title">regasm.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="MOTW">
-                
-                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="UAC">
-                
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
-                
-            </span>
-            
-            <div class="tool-lure-count">2 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/filefix.html" class="tool-item" data-id="filefix">
-        <div class="tool-title">FileFix (Explorer address bar)</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="CLI">
-                
-                CLI
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">3 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/finger.exe.html" class="tool-item" data-id="finger.exe">
-        <div class="tool-title">finger.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="CLI">
-                
-                CLI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/forfiles.exe.html" class="tool-item" data-id="forfiles.exe">
-        <div class="tool-title">forfiles.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="CLI">
-                
-                CLI
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <div class="tool-lure-count">4 lures</div>
-        </div>
-    </a>
-    
     <a href="/ClickGrab/techniques/ftp.exe.html" class="tool-item" data-id="ftp.exe">
         <div class="tool-title">ftp.exe</div>
         <div class="tool-tags">
@@ -684,65 +913,11 @@
             
             <span class="tool-tag capability-tag" data-capability="UAC">
                 
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 
             </span>
             
             <div class="tool-lure-count">2 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/net-use-webdav.html" class="tool-item" data-id="net-use-webdav">
-        <div class="tool-title">net use (WebDAV)</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="CLI">
-                
-                CLI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/crashfix.html" class="tool-item" data-id="crashfix">
-        <div class="tool-title">CrashFix</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="BROWSER">
-                
-                browser
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="CLI">
-                
-                CLI
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
         </div>
     </a>
     
@@ -763,384 +938,6 @@
             <span class="tool-tag capability-tag" data-capability="GUI">
                 
                 GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/certutil.exe.html" class="tool-item" data-id="certutil.exe">
-        <div class="tool-title">certutil.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="MOTW">
-                
-                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="UAC">
-                
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
-                
-            </span>
-            
-            <div class="tool-lure-count">2 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/credwiz.exe.html" class="tool-item" data-id="credwiz.exe">
-        <div class="tool-title">credwiz.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="MOTW">
-                
-                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="UAC">
-                
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
-                
-            </span>
-            
-            <div class="tool-lure-count">2 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/wextract.exe.html" class="tool-item" data-id="wextract.exe">
-        <div class="tool-title">wextract.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="CLI">
-                
-                CLI
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">2 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/certreq.exe.html" class="tool-item" data-id="certreq.exe">
-        <div class="tool-title">certreq.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="MOTW">
-                
-                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="UAC">
-                
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
-                
-            </span>
-            
-            <div class="tool-lure-count">2 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/perfmon.exe.html" class="tool-item" data-id="perfmon.exe">
-        <div class="tool-title">perfmon.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/control.exe.html" class="tool-item" data-id="control.exe">
-        <div class="tool-title">control.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="MOTW">
-                
-                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="UAC">
-                
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
-                
-            </span>
-            
-            <div class="tool-lure-count">3 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/CompMgmtLauncher.exe.html" class="tool-item" data-id="CompMgmtLauncher.exe">
-        <div class="tool-title">CompMgmtLauncher.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">4 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/ssh.exe.html" class="tool-item" data-id="ssh.exe">
-        <div class="tool-title">ssh.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="CLI">
-                
-                CLI
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="UAC">
-                
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/consentfix.html" class="tool-item" data-id="consentfix">
-        <div class="tool-title">ConsentFix</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="BROWSER">
-                
-                browser
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/fsquirt.exe.html" class="tool-item" data-id="fsquirt.exe">
-        <div class="tool-title">fsquirt.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/taskmgr.exe.html" class="tool-item" data-id="taskmgr.exe">
-        <div class="tool-title">taskmgr.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="GUI">
-                
-                GUI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/wt.exe.html" class="tool-item" data-id="wt.exe">
-        <div class="tool-title">wt.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="CLI">
-                
-                CLI
                 
             </span>
             
@@ -1190,8 +987,32 @@
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/eventvwr.exe.html" class="tool-item" data-id="eventvwr.exe">
-        <div class="tool-title">eventvwr.exe</div>
+    <a href="/ClickGrab/techniques/finger.exe.html" class="tool-item" data-id="finger.exe">
+        <div class="tool-title">finger.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="CLI">
+                
+                CLI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/control.exe.html" class="tool-item" data-id="control.exe">
+        <div class="tool-title">control.exe</div>
         <div class="tool-tags">
             <span class="tool-tag platform-tag" data-platform="Windows">
                 
@@ -1216,24 +1037,6 @@
                 
             </span>
             
-            <div class="tool-lure-count">2 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/mshta.exe.html" class="tool-item" data-id="mshta.exe">
-        <div class="tool-title">mshta.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
             <span class="tool-tag capability-tag" data-capability="MOTW">
                 
                 <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
@@ -1242,16 +1045,16 @@
             
             <span class="tool-tag capability-tag" data-capability="UAC">
                 
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 
             </span>
             
-            <div class="tool-lure-count">2 lures</div>
+            <div class="tool-lure-count">3 lures</div>
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/MRT.exe.html" class="tool-item" data-id="MRT.exe">
-        <div class="tool-title">MRT.exe</div>
+    <a href="/ClickGrab/techniques/credwiz.exe.html" class="tool-item" data-id="credwiz.exe">
+        <div class="tool-title">credwiz.exe</div>
         <div class="tool-tags">
             <span class="tool-tag platform-tag" data-platform="Windows">
                 
@@ -1278,7 +1081,7 @@
             
             <span class="tool-tag capability-tag" data-capability="UAC">
                 
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 
             </span>
             
@@ -1286,8 +1089,38 @@
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/powershell.exe.html" class="tool-item" data-id="powershell.exe">
-        <div class="tool-title">powershell.exe</div>
+    <a href="/ClickGrab/techniques/forfiles.exe.html" class="tool-item" data-id="forfiles.exe">
+        <div class="tool-title">forfiles.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="CLI">
+                
+                CLI
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <div class="tool-lure-count">4 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/regasm.exe.html" class="tool-item" data-id="regasm.exe">
+        <div class="tool-title">regasm.exe</div>
         <div class="tool-tags">
             <span class="tool-tag platform-tag" data-platform="Windows">
                 
@@ -1308,7 +1141,7 @@
             
             <span class="tool-tag capability-tag" data-capability="UAC">
                 
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 
             </span>
             
@@ -1316,8 +1149,8 @@
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/cmd.exe.html" class="tool-item" data-id="cmd.exe">
-        <div class="tool-title">cmd.exe</div>
+    <a href="/ClickGrab/techniques/wt.exe.html" class="tool-item" data-id="wt.exe">
+        <div class="tool-title">wt.exe</div>
         <div class="tool-tags">
             <span class="tool-tag platform-tag" data-platform="Windows">
                 
@@ -1330,13 +1163,43 @@
                 
             </span>
             
-            <span class="tool-tag capability-tag" data-capability="UAC">
+            <span class="tool-tag capability-tag" data-capability="CLI">
                 
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                CLI
                 
             </span>
             
-            <div class="tool-lure-count">2 lures</div>
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/fsquirt.exe.html" class="tool-item" data-id="fsquirt.exe">
+        <div class="tool-title">fsquirt.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
         </div>
     </a>
     
@@ -1370,74 +1233,8 @@
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/DxDiag.exe.html" class="tool-item" data-id="DxDiag.exe">
-        <div class="tool-title">DxDiag.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="MOTW">
-                
-                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/FileHistory.exe.html" class="tool-item" data-id="FileHistory.exe">
-        <div class="tool-title">FileHistory.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="GUI">
-                
-                gui
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="File Explorer">
-                
-                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="MOTW">
-                
-                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="UAC">
-                
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
-                
-            </span>
-            
-            <div class="tool-lure-count">2 lures</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/msbuild.exe.html" class="tool-item" data-id="msbuild.exe">
-        <div class="tool-title">msbuild.exe</div>
+    <a href="/ClickGrab/techniques/rundll32.exe.html" class="tool-item" data-id="rundll32.exe">
+        <div class="tool-title">rundll32.exe</div>
         <div class="tool-tags">
             <span class="tool-tag platform-tag" data-platform="Windows">
                 
@@ -1458,7 +1255,43 @@
             
             <span class="tool-tag capability-tag" data-capability="UAC">
                 
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
+                
+            </span>
+            
+            <div class="tool-lure-count">2 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/certreq.exe.html" class="tool-item" data-id="certreq.exe">
+        <div class="tool-title">certreq.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="MOTW">
+                
+                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="UAC">
+                
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 
             </span>
             
@@ -1490,32 +1323,8 @@
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/msiexec.exe.html" class="tool-item" data-id="msiexec.exe">
-        <div class="tool-title">msiexec.exe</div>
-        <div class="tool-tags">
-            <span class="tool-tag platform-tag" data-platform="Windows">
-                
-                windows
-                
-            </span>
-            <span class="tool-tag presentation-tag" data-presentation="CLI">
-                
-                cli
-                
-            </span>
-            
-            <span class="tool-tag capability-tag" data-capability="CLI">
-                
-                CLI
-                
-            </span>
-            
-            <div class="tool-lure-count">1 lure</div>
-        </div>
-    </a>
-    
-    <a href="/ClickGrab/techniques/dcomcnfg.exe.html" class="tool-item" data-id="dcomcnfg.exe">
-        <div class="tool-title">dcomcnfg.exe</div>
+    <a href="/ClickGrab/techniques/CompMgmtLauncher.exe.html" class="tool-item" data-id="CompMgmtLauncher.exe">
+        <div class="tool-title">CompMgmtLauncher.exe</div>
         <div class="tool-tags">
             <span class="tool-tag platform-tag" data-platform="Windows">
                 
@@ -1537,6 +1346,72 @@
             <span class="tool-tag capability-tag" data-capability="GUI">
                 
                 GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">4 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/FileHistory.exe.html" class="tool-item" data-id="FileHistory.exe">
+        <div class="tool-title">FileHistory.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="MOTW">
+                
+                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="UAC">
+                
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
+                
+            </span>
+            
+            <div class="tool-lure-count">2 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/ssh.exe.html" class="tool-item" data-id="ssh.exe">
+        <div class="tool-title">ssh.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="CLI">
+                
+                CLI
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="UAC">
+                
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 
             </span>
             
@@ -1586,8 +1461,68 @@
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/rundll32.exe.html" class="tool-item" data-id="rundll32.exe">
-        <div class="tool-title">rundll32.exe</div>
+    <a href="/ClickGrab/techniques/net-use-webdav.html" class="tool-item" data-id="net-use-webdav">
+        <div class="tool-title">net use (WebDAV)</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="CLI">
+                
+                CLI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/osascript.html" class="tool-item" data-id="osascript">
+        <div class="tool-title">osascript</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Mac">
+                
+                mac
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="CLI">
+                
+                CLI
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="Credential Theft">
+                
+                Credential Theft
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="Data Exfiltration">
+                
+                Data Exfiltration
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/wscript.exe.html" class="tool-item" data-id="wscript.exe">
+        <div class="tool-title">wscript.exe</div>
         <div class="tool-tags">
             <span class="tool-tag platform-tag" data-platform="Windows">
                 
@@ -1608,7 +1543,37 @@
             
             <span class="tool-tag capability-tag" data-capability="UAC">
                 
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
+                
+            </span>
+            
+            <div class="tool-lure-count">2 lures</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/mshta.exe.html" class="tool-item" data-id="mshta.exe">
+        <div class="tool-title">mshta.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="MOTW">
+                
+                <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="UAC">
+                
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 
             </span>
             
@@ -1640,8 +1605,8 @@
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/wscript.exe.html" class="tool-item" data-id="wscript.exe">
-        <div class="tool-title">wscript.exe</div>
+    <a href="/ClickGrab/techniques/msbuild.exe.html" class="tool-item" data-id="msbuild.exe">
+        <div class="tool-title">msbuild.exe</div>
         <div class="tool-tags">
             <span class="tool-tag platform-tag" data-platform="Windows">
                 
@@ -1662,7 +1627,7 @@
             
             <span class="tool-tag capability-tag" data-capability="UAC">
                 
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 
             </span>
             
@@ -1670,8 +1635,38 @@
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/colorcpl.exe.html" class="tool-item" data-id="colorcpl.exe">
-        <div class="tool-title">colorcpl.exe</div>
+    <a href="/ClickGrab/techniques/perfmon.exe.html" class="tool-item" data-id="perfmon.exe">
+        <div class="tool-title">perfmon.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="GUI">
+                
+                gui
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="File Explorer">
+                
+                <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="GUI">
+                
+                GUI
+                
+            </span>
+            
+            <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/MRT.exe.html" class="tool-item" data-id="MRT.exe">
+        <div class="tool-title">MRT.exe</div>
         <div class="tool-tags">
             <span class="tool-tag platform-tag" data-platform="Windows">
                 
@@ -1696,12 +1691,18 @@
                 
             </span>
             
+            <span class="tool-tag capability-tag" data-capability="UAC">
+                
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
+                
+            </span>
+            
             <div class="tool-lure-count">2 lures</div>
         </div>
     </a>
     
-    <a href="/ClickGrab/techniques/msra.exe.html" class="tool-item" data-id="msra.exe">
-        <div class="tool-title">msra.exe</div>
+    <a href="/ClickGrab/techniques/DxDiag.exe.html" class="tool-item" data-id="DxDiag.exe">
+        <div class="tool-title">DxDiag.exe</div>
         <div class="tool-tags">
             <span class="tool-tag platform-tag" data-platform="Windows">
                 
@@ -1727,6 +1728,30 @@
             </span>
             
             <div class="tool-lure-count">1 lure</div>
+        </div>
+    </a>
+    
+    <a href="/ClickGrab/techniques/cmd.exe.html" class="tool-item" data-id="cmd.exe">
+        <div class="tool-title">cmd.exe</div>
+        <div class="tool-tags">
+            <span class="tool-tag platform-tag" data-platform="Windows">
+                
+                windows
+                
+            </span>
+            <span class="tool-tag presentation-tag" data-presentation="CLI">
+                
+                cli
+                
+            </span>
+            
+            <span class="tool-tag capability-tag" data-capability="UAC">
+                
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
+                
+            </span>
+            
+            <div class="tool-lure-count">2 lures</div>
         </div>
     </a>
     

--- a/public/techniques/CompMgmtLauncher.exe.html
+++ b/public/techniques/CompMgmtLauncher.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CompMgmtLauncher.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -513,7 +547,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -606,7 +640,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -675,7 +709,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -746,7 +780,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/public/techniques/DxDiag.exe.html
+++ b/public/techniques/DxDiag.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>DxDiag.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,13 +505,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
@@ -512,13 +546,13 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/public/techniques/FileHistory.exe.html
+++ b/public/techniques/FileHistory.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>FileHistory.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -467,19 +501,19 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -514,13 +548,13 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
@@ -580,19 +614,19 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/public/techniques/MRT.exe.html
+++ b/public/techniques/MRT.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MRT.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,19 +505,19 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -520,19 +554,19 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -608,19 +642,19 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/public/techniques/Terminal.html
+++ b/public/techniques/Terminal.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Terminal - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/public/techniques/certreq.exe.html
+++ b/public/techniques/certreq.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>certreq.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -467,19 +501,19 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -516,13 +550,13 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -589,19 +623,19 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/public/techniques/certutil.exe.html
+++ b/public/techniques/certutil.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>certutil.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,13 +505,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -513,7 +547,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
@@ -621,7 +655,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/public/techniques/clickonce.html
+++ b/public/techniques/clickonce.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ClickOnce launcher (dfshim) - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/public/techniques/cmd.exe.html
+++ b/public/techniques/cmd.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>cmd.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -467,7 +501,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -586,7 +620,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/public/techniques/colorcpl.exe.html
+++ b/public/techniques/colorcpl.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>colorcpl.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -467,13 +501,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
@@ -508,13 +542,13 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
@@ -598,13 +632,13 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 

--- a/public/techniques/conhost.exe.html
+++ b/public/techniques/conhost.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>conhost.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -467,7 +501,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -580,7 +614,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/public/techniques/consentfix.html
+++ b/public/techniques/consentfix.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ConsentFix - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/public/techniques/control.exe.html
+++ b/public/techniques/control.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>control.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -483,13 +517,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -524,13 +558,13 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -588,19 +622,19 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 
@@ -666,7 +700,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/public/techniques/crashfix.html
+++ b/public/techniques/crashfix.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CrashFix - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/public/techniques/credwiz.exe.html
+++ b/public/techniques/credwiz.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>credwiz.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,19 +505,19 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -520,13 +554,13 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -593,19 +627,19 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/public/techniques/dcomcnfg.exe.html
+++ b/public/techniques/dcomcnfg.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>dcomcnfg.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -513,7 +547,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/public/techniques/eventvwr.exe.html
+++ b/public/techniques/eventvwr.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>eventvwr.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -512,7 +546,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -590,7 +624,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/public/techniques/explorer-shell-uris.html
+++ b/public/techniques/explorer-shell-uris.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>explorer shell URIs - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -512,7 +546,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -588,7 +622,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/public/techniques/fake-google-meet.html
+++ b/public/techniques/fake-google-meet.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Fake Google Meet ClickFix - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/public/techniques/filefix.html
+++ b/public/techniques/filefix.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>FileFix (Explorer address bar) - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -477,7 +511,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -519,7 +553,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -615,7 +649,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -691,7 +725,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/public/techniques/finger.exe.html
+++ b/public/techniques/finger.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>finger.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/public/techniques/forfiles.exe.html
+++ b/public/techniques/forfiles.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>forfiles.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -477,7 +511,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -605,7 +639,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -688,7 +722,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 
@@ -771,7 +805,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/public/techniques/fsquirt.exe.html
+++ b/public/techniques/fsquirt.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>fsquirt.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -513,7 +547,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/public/techniques/ftp.exe.html
+++ b/public/techniques/ftp.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ftp.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -472,7 +506,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -586,7 +620,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/public/techniques/iexpress.exe.html
+++ b/public/techniques/iexpress.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>iexpress.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -512,7 +546,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/public/techniques/msbuild.exe.html
+++ b/public/techniques/msbuild.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>msbuild.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,13 +505,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -513,7 +547,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
@@ -619,7 +653,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/public/techniques/mshta.exe.html
+++ b/public/techniques/mshta.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>mshta.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,13 +505,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -513,7 +547,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
@@ -621,7 +655,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/public/techniques/msiexec.exe.html
+++ b/public/techniques/msiexec.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>msiexec.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/public/techniques/msra.exe.html
+++ b/public/techniques/msra.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>msra.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,13 +505,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
@@ -514,13 +548,13 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/public/techniques/net-use-webdav.html
+++ b/public/techniques/net-use-webdav.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>net use (WebDAV) - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/public/techniques/nslookup.exe.html
+++ b/public/techniques/nslookup.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>nslookup.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/public/techniques/office-uri.html
+++ b/public/techniques/office-uri.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Office URI schemes (ms-word/ms-excel) - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -519,7 +553,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/public/techniques/osascript.html
+++ b/public/techniques/osascript.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>osascript - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/public/techniques/perfmon.exe.html
+++ b/public/techniques/perfmon.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>perfmon.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -512,7 +546,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/public/techniques/powershell.exe.html
+++ b/public/techniques/powershell.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>powershell.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,13 +505,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -513,7 +547,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
@@ -623,7 +657,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/public/techniques/regasm.exe.html
+++ b/public/techniques/regasm.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>regasm.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,13 +505,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -513,7 +547,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
@@ -619,7 +653,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/public/techniques/rundll32.exe.html
+++ b/public/techniques/rundll32.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>rundll32.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,13 +505,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -513,7 +547,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
@@ -619,7 +653,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/public/techniques/search-ms.html
+++ b/public/techniques/search-ms.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>search-ms protocol - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -512,7 +546,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/public/techniques/ssh.exe.html
+++ b/public/techniques/ssh.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ssh.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -477,7 +511,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -519,7 +553,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/public/techniques/steganography-clickfix.html
+++ b/public/techniques/steganography-clickfix.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Steganography ClickFix (Stego Loader) - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/public/techniques/taskmgr.exe.html
+++ b/public/techniques/taskmgr.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>taskmgr.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,7 +505,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -512,7 +546,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/public/techniques/wextract.exe.html
+++ b/public/techniques/wextract.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>wextract.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -477,7 +511,7 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             
         </span>
         
@@ -518,7 +552,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     
                 </span>
                 

--- a/public/techniques/wscript.exe.html
+++ b/public/techniques/wscript.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>wscript.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -471,13 +505,13 @@
         
         <span class="technique-tag">
             
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             
         </span>
         
         <span class="technique-tag">
             
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             
         </span>
         
@@ -513,7 +547,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     
                 </span>
                 
@@ -619,7 +653,7 @@
                 
                 <span class="capability-tag">
                     
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     
                 </span>
                 

--- a/public/techniques/wt.exe.html
+++ b/public/techniques/wt.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>wt.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/public/techniques/wusa.exe.html
+++ b/public/techniques/wusa.exe.html
@@ -5,53 +5,52 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>wusa.exe - ClickFix Techniques</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/ClickGrab/assets/css/styles.css">
     <link rel="icon" href="/ClickGrab/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -59,17 +58,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -80,18 +81,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -101,12 +108,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -129,20 +143,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -151,12 +166,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -164,9 +181,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -180,24 +197,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -219,12 +238,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -235,46 +254,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -285,110 +304,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */

--- a/redirect_follower.py
+++ b/redirect_follower.py
@@ -17,10 +17,15 @@ JS_HEADERS = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36"
 }
 
-_MAX_EXTERNAL_SCRIPTS = 8
+_MAX_EXTERNAL_SCRIPTS = 5
 _MAX_INLINE_SCRIPTS = 12
-_MAX_FOLLOWED_URLS = 10
-_FOLLOW_TIMEOUT = 6
+_MAX_FOLLOWED_URLS = 6
+# (connect, read): a host that connects then stalls is bounded by the read timeout.
+_FOLLOW_TIMEOUT = (4, 6)
+# Hard wall-clock ceiling for the whole redirect-following stage of one URL, so a
+# page full of slow external scripts can't freeze a batch scan. Partial results
+# (whatever was collected before the budget ran out) are still returned.
+_STAGE_BUDGET_SECONDS = 22
 _MAX_SNIPPET_LEN = 240
 _MAX_FETCH_SNIPPET = 2000
 
@@ -44,6 +49,34 @@ class _Candidate:
     method: str
     script_url: Optional[str]
     evidence: str
+
+
+def _read_capped(response, max_bytes: int, deadline: Optional[float] = None) -> str:
+    """Stream a response body with a byte cap + wall-clock deadline.
+
+    Bounds total transfer time so a host trickling bytes can't stall the stage
+    (requests' read timeout only bounds the gap between chunks, not the total).
+    """
+    import time as _t
+    chunks = []
+    total = 0
+    try:
+        for chunk in response.iter_content(8192):
+            if chunk:
+                chunks.append(chunk)
+                total += len(chunk)
+            if total >= max_bytes:
+                break
+            if deadline is not None and _t.monotonic() > deadline:
+                break
+    except requests.RequestException:
+        pass
+    raw = b"".join(chunks)
+    enc = response.encoding or "utf-8"
+    try:
+        return raw.decode(enc, errors="ignore")
+    except (LookupError, TypeError):
+        return raw.decode("utf-8", errors="ignore")
 
 
 def _safe_decode(value: str) -> Optional[str]:
@@ -160,16 +193,16 @@ def _collect_meta_refresh(base_url: str, soup: BeautifulSoup) -> List[_Candidate
     return findings
 
 
-def _follow_destination(session: requests.Session, url: str) -> RedirectFollow:
+def _follow_destination(session: requests.Session, url: str, deadline: Optional[float] = None) -> RedirectFollow:
     history_urls: List[str] = []
     final_url: Optional[str] = None
     status = "ok"
     snippet = None
     try:
-        response = session.get(url, timeout=_FOLLOW_TIMEOUT, allow_redirects=True)
+        response = session.get(url, timeout=_FOLLOW_TIMEOUT, allow_redirects=True, stream=True)
         history_urls = [resp.url for resp in response.history]
         final_url = response.url
-        snippet = response.text[:_MAX_FETCH_SNIPPET]
+        snippet = _read_capped(response, max_bytes=100_000, deadline=deadline)[:_MAX_FETCH_SNIPPET]
     except requests.RequestException as exc:
         status = f"error: {exc}"[:200]
     return final_url, history_urls, status, snippet
@@ -190,6 +223,12 @@ def _dedupe_candidates(candidates: Iterable[_Candidate], limit: int) -> List[_Ca
 
 
 def collect_redirects(base_url: str, html_content: str) -> List[RedirectFollow]:
+    import time as _time
+    _budget_start = _time.monotonic()
+
+    def _over_budget() -> bool:
+        return _time.monotonic() - _budget_start > _STAGE_BUDGET_SECONDS
+
     soup = BeautifulSoup(html_content, "html.parser")
 
     candidates: List[_Candidate] = []
@@ -220,10 +259,13 @@ def collect_redirects(base_url: str, html_content: str) -> List[RedirectFollow]:
     session.verify = False
 
     for script_url in external_urls:
+        if _over_budget():
+            logger.debug("Redirect stage budget exceeded while fetching scripts; stopping.")
+            break
         try:
-            resp = session.get(script_url, timeout=_FOLLOW_TIMEOUT, allow_redirects=True)
+            resp = session.get(script_url, timeout=_FOLLOW_TIMEOUT, allow_redirects=True, stream=True)
             resp.raise_for_status()
-            script_text = resp.text
+            script_text = _read_capped(resp, max_bytes=500_000, deadline=_budget_start + _STAGE_BUDGET_SECONDS)
             logger.debug("Fetched script %s (size=%d)", script_url, len(script_text))
             candidates.extend(_collect_from_script(script_url, script_text, "external_js"))
         except requests.RequestException as exc:
@@ -240,7 +282,12 @@ def collect_redirects(base_url: str, html_content: str) -> List[RedirectFollow]:
     deduped_candidates = _dedupe_candidates(candidates, _MAX_FOLLOWED_URLS)
 
     for candidate in deduped_candidates:
-        final_url, history, status, snippet = _follow_destination(session, candidate.original_url)
+        if _over_budget():
+            logger.debug("Redirect stage budget exceeded while following URLs; stopping.")
+            break
+        final_url, history, status, snippet = _follow_destination(
+            session, candidate.original_url, deadline=_budget_start + _STAGE_BUDGET_SECONDS
+        )
         findings.append(
             RedirectFollow(
                 Source=candidate.source,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -19,11 +19,39 @@ import re
 import urllib3
 import warnings
 import yaml
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as _FuturesTimeout
 from datetime import datetime
 from pathlib import Path
 
 from clickgrab import analyze_url, download_urlhaus_data, sanitize_url
 from models import AnalysisVerdict
+
+# Hard per-URL wall-clock ceiling for the UI. analyze_url already bounds its own
+# network stages, but this backstop guarantees the scan loop ALWAYS advances —
+# even if a host does something pathological that slips past those timeouts.
+_ANALYZE_TIMEOUT = 75
+
+
+@st.cache_resource
+def _get_analyze_executor():
+    return ThreadPoolExecutor(max_workers=4, thread_name_prefix="clickgrab-analyze")
+
+
+def _analyze_with_timeout(url, timeout=_ANALYZE_TIMEOUT):
+    """Run analyze_url with a hard wall-clock cap.
+
+    Returns (result_or_None, timed_out: bool). On timeout the worker thread is
+    abandoned (it finishes on its own once its bounded network calls return) and
+    the caller moves on to the next URL.
+    """
+    future = _get_analyze_executor().submit(analyze_url, url)
+    try:
+        return future.result(timeout=timeout), False
+    except _FuturesTimeout:
+        future.cancel()
+        return None, True
+    except Exception as exc:  # never let one bad URL kill the whole batch
+        return None, False
 
 from ui.categories import FINDING_CATEGORIES
 from ui.helpers import _val, _count, _category_counts
@@ -182,10 +210,21 @@ def _scan_single():
     if submitted and url:
         with st.status("Analyzing...", expanded=True) as status:
             st.write(f"Fetching content from `{url}`...")
-            result = analyze_url(url)
-            status.update(label="Analysis complete", state="complete")
+            result, timed_out = _analyze_with_timeout(sanitize_url(url))
+            if timed_out:
+                status.update(
+                    label=f"Timed out after {_ANALYZE_TIMEOUT}s", state="error"
+                )
+            else:
+                status.update(label="Analysis complete", state="complete")
 
-        if result:
+        if timed_out:
+            st.warning(
+                f"Analysis timed out after {_ANALYZE_TIMEOUT}s — the target may be "
+                "slow or deliberately stalling. Try again or use Batch mode.",
+                icon=":material/timer_off:",
+            )
+        elif result:
             st.session_state["scan_results"] = [result]
             st.toast("Analysis complete!", icon=":material/check_circle:")
             _render_result(result)
@@ -209,17 +248,22 @@ def _scan_batch():
         ][:limit]
         results = []
 
+        skipped = 0
         with st.status(f"Analyzing {len(raw_urls)} URLs...", expanded=True) as status:
             progress = st.progress(0)
             for i, url in enumerate(raw_urls):
                 st.write(f"`{url}`")
-                r = analyze_url(sanitize_url(url))
-                if r:
+                r, timed_out = _analyze_with_timeout(sanitize_url(url))
+                if timed_out:
+                    skipped += 1
+                    st.write(f":orange[timed out after {_ANALYZE_TIMEOUT}s — skipped]")
+                elif r:
                     results.append(r)
                 progress.progress((i + 1) / len(raw_urls))
-            status.update(
-                label=f"Done -- {len(results)} analyzed", state="complete"
-            )
+            label = f"Done -- {len(results)} analyzed"
+            if skipped:
+                label += f", {skipped} skipped (timeout)"
+            status.update(label=label, state="complete")
 
         if results:
             st.session_state["scan_results"] = results
@@ -257,16 +301,21 @@ def _scan_urlhaus():
 
             st.write(f"Found **{len(urls)}** URLs. Analyzing...")
             results = []
+            skipped = 0
             progress = st.progress(0)
             for i, url in enumerate(urls):
                 st.write(f"`{url}`")
-                r = analyze_url(url)
-                if r:
+                r, timed_out = _analyze_with_timeout(url)
+                if timed_out:
+                    skipped += 1
+                    st.write(f":orange[timed out after {_ANALYZE_TIMEOUT}s — skipped]")
+                elif r:
                     results.append(r)
                 progress.progress((i + 1) / len(urls))
-            status.update(
-                label=f"Done -- {len(results)} analyzed", state="complete"
-            )
+            label = f"Done -- {len(results)} analyzed"
+            if skipped:
+                label += f", {skipped} skipped (timeout)"
+            status.update(label=label, state="complete")
 
         if results:
             st.session_state["scan_results"] = results

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -6,17 +6,19 @@
 <style>
     /* Blog-specific styles */
     .analysis-hero {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: linear-gradient(135deg, var(--surface) 0%, var(--surface-3) 100%);
+        color: var(--text);
         text-align: center;
         padding: 4rem 2rem;
         border-radius: var(--border-radius);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
         margin-bottom: 3rem;
-        box-shadow: var(--shadow-lg);
+        box-shadow: var(--shadow);
         position: relative;
         overflow: hidden;
     }
-    
+
     .analysis-hero::before {
         content: '';
         position: absolute;
@@ -24,205 +26,217 @@
         left: 0;
         right: 0;
         bottom: 0;
-        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="20" cy="20" r="2" fill="rgba(255,255,255,0.1)"/><circle cx="80" cy="40" r="1.5" fill="rgba(255,255,255,0.1)"/><circle cx="40" cy="60" r="1" fill="rgba(255,255,255,0.1)"/><circle cx="70" cy="80" r="2.5" fill="rgba(255,255,255,0.1)"/></svg>') repeat;
+        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="20" cy="20" r="2" fill="rgba(0,255,136,0.08)"/><circle cx="80" cy="40" r="1.5" fill="rgba(0,255,136,0.08)"/><circle cx="40" cy="60" r="1" fill="rgba(0,255,136,0.08)"/><circle cx="70" cy="80" r="2.5" fill="rgba(0,255,136,0.08)"/></svg>') repeat;
         pointer-events: none;
     }
-    
+
     .analysis-hero .content {
         position: relative;
         z-index: 1;
     }
-    
+
     .analysis-hero h1 {
         font-size: 3rem;
         margin-bottom: 1rem;
         border-bottom: none;
-        color: white;
-        background: linear-gradient(45deg, #fff, #f0f8ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 2px;
+        color: var(--accent);
     }
-    
+
     .analysis-hero p {
         font-size: 1.3rem;
         opacity: 1;
         max-width: 600px;
         margin: 0 auto;
-        color: rgba(255, 255, 255, 0.95);
-        text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+        color: var(--text-soft);
         font-weight: 400;
     }
-    
+
     /* Key Insights Section */
     .key-insights {
-        background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
-        border-radius: 16px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 2rem;
         margin-bottom: 3rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border: 1px solid #e2e8f0;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
     }
-    
+
     .insights-header {
         display: flex;
         align-items: center;
         gap: 1rem;
         margin-bottom: 1.5rem;
     }
-    
+
     .insights-icon {
         width: 48px;
         height: 48px;
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        border-radius: 12px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         display: flex;
         align-items: center;
         justify-content: center;
         font-size: 24px;
     }
-    
+
     .insights-title {
         font-size: 1.75rem;
-        font-weight: 700;
-        color: var(--text-color);
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
     }
-    
+
     .insights-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
         gap: 1.5rem;
     }
-    
+
     .insight-item {
         text-align: center;
         padding: 1.5rem;
-        background: white;
-        border-radius: 12px;
-        border: 1px solid #e2e8f0;
-        transition: all 0.3s ease;
+        background: var(--surface-2);
+        border-radius: var(--border-radius);
+        border: 1px solid var(--border);
+        transition: all 0.18s ease;
     }
-    
+
     .insight-item:hover {
         transform: translateY(-3px);
-        box-shadow: 0 8px 20px rgba(0,0,0,0.1);
+        border-color: var(--accent);
+        box-shadow: var(--shadow);
     }
-    
+
     .insight-value {
         font-size: 2.5rem;
+        font-family: var(--font-mono);
         font-weight: 700;
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
         display: block;
         margin-bottom: 0.5rem;
     }
-    
+
     .insight-label {
         font-size: 0.9rem;
-        color: var(--text-light);
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        color: var(--muted);
         font-weight: 500;
     }
-    
+
     /* Search and Filter Bar */
     .analysis-controls {
-        background: white;
-        border-radius: 16px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 1.5rem;
         margin-bottom: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border: 1px solid #e2e8f0;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
     }
-    
+
     .controls-row {
         display: flex;
         gap: 1rem;
         align-items: center;
         flex-wrap: wrap;
     }
-    
+
     .search-box {
         flex: 2;
         position: relative;
         min-width: 300px;
     }
-    
+
     .search-input {
         width: 100%;
         padding: 0.75rem 1rem 0.75rem 3rem;
-        border: 2px solid #e2e8f0;
-        border-radius: 10px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        color: var(--text);
         font-size: 1rem;
-        transition: all 0.3s ease;
+        transition: all 0.18s ease;
     }
-    
+
+    .search-input::placeholder {
+        color: var(--muted);
+    }
+
     .search-input:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
-    
+
     .search-icon {
         position: absolute;
         left: 1rem;
         top: 50%;
         transform: translateY(-50%);
-        color: #94a3b8;
+        color: var(--muted);
     }
-    
+
     .filter-chips {
         display: flex;
         gap: 0.5rem;
         flex-wrap: wrap;
         flex: 1;
     }
-    
+
     .filter-chip {
         padding: 0.5rem 1rem;
-        background: #f1f5f9;
-        border: 2px solid transparent;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
         border-radius: 20px;
+        font-family: var(--font-mono);
         font-size: 0.9rem;
         font-weight: 500;
         cursor: pointer;
-        transition: all 0.3s ease;
-        color: var(--text-light);
+        transition: all 0.18s ease;
+        color: var(--text-soft);
     }
-    
+
     .filter-chip:hover {
-        background: #e2e8f0;
+        background: var(--surface-3);
+        border-color: var(--accent);
     }
-    
+
     .filter-chip.active {
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        color: white;
-        border-color: transparent;
+        background: var(--accent);
+        color: var(--bg);
+        border-color: var(--accent);
     }
-    
+
     .blog-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
         gap: 2rem;
         margin-bottom: 3rem;
     }
-    
+
     .blog-card {
-        background: white;
-        border-radius: 12px;
-        box-shadow: 0 8px 32px rgba(0,0,0,0.12);
+        background: var(--surface);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
         overflow: hidden;
-        transition: all 0.3s ease;
-        border: 1px solid rgba(255,255,255,0.2);
+        transition: all 0.18s ease;
+        border: 1px solid var(--border);
         position: relative;
         opacity: 0;
         animation: fadeInUp 0.6s ease forwards;
     }
-    
+
     .blog-card:nth-child(1) { animation-delay: 0.1s; }
     .blog-card:nth-child(2) { animation-delay: 0.2s; }
     .blog-card:nth-child(3) { animation-delay: 0.3s; }
-    
+
     @keyframes fadeInUp {
         from {
             opacity: 0;
@@ -233,189 +247,214 @@
             transform: translateY(0);
         }
     }
-    
+
     .blog-card:hover {
         transform: translateY(-8px);
-        box-shadow: 0 20px 40px rgba(0,0,0,0.15);
+        border-color: var(--accent);
+        box-shadow: var(--shadow);
     }
-    
+
     .blog-card::before {
         content: '';
         position: absolute;
         top: 0;
         left: 0;
         right: 0;
-        height: 4px;
-        background: linear-gradient(90deg, var(--primary-color), var(--accent-color));
+        height: 3px;
+        background: var(--accent);
+        z-index: 1;
     }
-    
+
     .blog-header {
-        background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+        background: var(--surface-2);
         padding: 1.5rem;
-        border-bottom: 1px solid #e2e8f0;
+        border-bottom: 1px solid var(--border);
     }
-    
+
     .blog-meta {
         display: flex;
         align-items: center;
         gap: 1rem;
         margin-bottom: 1rem;
         font-size: 0.9rem;
-        color: var(--text-light);
+        color: var(--muted);
     }
-    
+
     .blog-date {
-        background: var(--primary-color);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent);
+        font-family: var(--font-mono);
         padding: 0.25rem 0.75rem;
         border-radius: 20px;
         font-weight: 500;
         font-size: 0.8rem;
     }
-    
+
     .blog-category {
-        background: linear-gradient(45deg, #ff6b6b, #ee5a24);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent3);
+        color: var(--accent3);
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
         padding: 0.25rem 0.75rem;
         border-radius: 20px;
         font-weight: 500;
         font-size: 0.8rem;
     }
-    
+
     .blog-title {
         font-size: 1.5rem;
-        font-weight: 700;
-        color: var(--text-color);
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin-bottom: 0.5rem;
         line-height: 1.3;
     }
-    
+
     .blog-excerpt {
-        color: var(--text-light);
+        color: var(--text-soft);
         line-height: 1.6;
         font-size: 1rem;
     }
-    
+
     .blog-content {
         padding: 1.5rem;
     }
-    
+
     .blog-stats {
         display: flex;
         gap: 1.5rem;
         margin-bottom: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .blog-stat {
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        color: white;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-top: 2px solid var(--accent);
+        color: var(--text);
         padding: 0.75rem 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         text-align: center;
         flex: 1;
         min-width: 80px;
     }
-    
+
     .blog-stat-number {
         font-size: 1.5rem;
+        font-family: var(--font-mono);
         font-weight: 700;
+        color: var(--accent);
         display: block;
     }
-    
+
     .blog-stat-label {
         font-size: 0.75rem;
-        opacity: 0.9;
+        font-family: var(--font-mono);
+        color: var(--muted);
         text-transform: uppercase;
         letter-spacing: 0.5px;
     }
-    
+
     .blog-tags {
         display: flex;
         flex-wrap: wrap;
         gap: 0.5rem;
         margin-bottom: 1.5rem;
     }
-    
+
     .blog-tag {
-        background: linear-gradient(45deg, #22c55e, #0891b2);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent);
+        font-family: var(--font-mono);
         padding: 0.25rem 0.75rem;
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
     }
-    
+
     .blog-actions {
         display: flex;
         gap: 1rem;
         align-items: center;
     }
-    
+
     .read-more {
-        background: linear-gradient(45deg, var(--primary-color), #4c51bf);
-        color: white;
+        background: var(--accent);
+        color: var(--bg);
         padding: 0.75rem 1.5rem;
-        border-radius: 25px;
+        border-radius: var(--border-radius);
         text-decoration: none;
+        font-family: var(--font-mono);
         font-weight: 600;
-        transition: all 0.3s ease;
-        box-shadow: 0 4px 15px rgba(37, 99, 235, 0.3);
+        letter-spacing: 0.5px;
+        transition: all 0.18s ease;
         flex: 1;
         text-align: center;
     }
-    
+
     .read-more:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(37, 99, 235, 0.4);
-        color: white;
+        background: var(--accent-dim);
+        color: var(--bg);
     }
-    
+
     .share-btn {
-        background: linear-gradient(45deg, #48bb78, #38a169);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent);
         padding: 0.75rem;
         border-radius: 50%;
         text-decoration: none;
-        transition: all 0.3s ease;
+        transition: all 0.18s ease;
         width: 45px;
         height: 45px;
         display: flex;
         align-items: center;
         justify-content: center;
     }
-    
+
     .share-btn:hover {
         transform: rotate(5deg) scale(1.1);
-        color: white;
+        border-color: var(--accent);
+        color: var(--accent);
     }
-    
+
     .featured-badge {
         position: absolute;
         top: 1rem;
         right: 1rem;
-        background: linear-gradient(45deg, #ffd700, #ffed4e);
-        color: #000;
+        background: var(--accent4);
+        color: var(--bg);
         padding: 0.5rem 1rem;
         border-radius: 20px;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
         font-size: 0.8rem;
         font-weight: 700;
         z-index: 2;
-        box-shadow: 0 4px 15px rgba(255, 215, 0, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     /* Newsletter Signup */
     .newsletter-section {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        border-radius: 16px;
+        background: linear-gradient(135deg, var(--surface) 0%, var(--surface-3) 100%);
+        border-radius: var(--border-radius);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
         padding: 3rem 2rem;
         margin: 3rem 0;
         text-align: center;
-        color: white;
+        color: var(--text);
         position: relative;
         overflow: hidden;
     }
-    
+
     .newsletter-section::before {
         content: '';
         position: absolute;
@@ -423,34 +462,36 @@
         right: -50%;
         width: 200%;
         height: 200%;
-        background: radial-gradient(circle, rgba(255,255,255,0.1) 0%, transparent 70%);
+        background: radial-gradient(circle, rgba(0,255,136,0.06) 0%, transparent 70%);
         animation: pulse 15s ease-in-out infinite;
     }
-    
+
     @keyframes pulse {
         0%, 100% { transform: scale(0.8); opacity: 0.5; }
         50% { transform: scale(1.2); opacity: 0.8; }
     }
-    
+
     .newsletter-content {
         position: relative;
         z-index: 1;
     }
-    
+
     .newsletter-title {
         font-size: 2rem;
         margin-bottom: 1rem;
-        font-weight: 700;
-        color: white;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent);
     }
-    
+
     .newsletter-desc {
         font-size: 1.1rem;
         margin-bottom: 2rem;
         opacity: 1;
-        color: white;
+        color: var(--text-soft);
     }
-    
+
     .newsletter-form {
         display: flex;
         gap: 1rem;
@@ -459,71 +500,72 @@
         flex-wrap: wrap;
         justify-content: center;
     }
-    
+
     .newsletter-input {
         flex: 1;
         min-width: 250px;
         padding: 0.75rem 1.5rem;
-        border: 2px solid rgba(255,255,255,0.3);
+        border: 1px solid var(--border);
         border-radius: 30px;
-        background: rgba(255,255,255,0.1);
-        color: white;
+        background: var(--surface-2);
+        color: var(--text);
         font-size: 1rem;
-        transition: all 0.3s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .newsletter-input::placeholder {
-        color: rgba(255,255,255,0.7);
+        color: var(--muted);
     }
-    
+
     .newsletter-input:focus {
         outline: none;
-        border-color: white;
-        background: rgba(255,255,255,0.2);
+        border-color: var(--accent);
+        background: var(--surface-3);
     }
-    
+
     .newsletter-submit {
         padding: 0.75rem 2rem;
-        background: white;
-        color: #0e7490;
+        background: var(--accent);
+        color: var(--bg);
         border: none;
         border-radius: 30px;
+        font-family: var(--font-mono);
         font-weight: 600;
+        letter-spacing: 0.5px;
         font-size: 1rem;
         cursor: pointer;
-        transition: all 0.3s ease;
-        box-shadow: 0 4px 15px rgba(0,0,0,0.2);
+        transition: all 0.18s ease;
     }
-    
+
     .newsletter-submit:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(0,0,0,0.3);
+        background: var(--accent-dim);
     }
-    
+
     .coming-soon {
         text-align: center;
         padding: 3rem 2rem;
-        background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
-        border-radius: 12px;
-        border: 2px dashed #cbd5e0;
+        background: var(--surface-2);
+        border-radius: var(--border-radius);
+        border: 2px dashed var(--border);
         margin-top: 2rem;
     }
-    
+
     .coming-soon h3 {
-        color: var(--text-light);
+        color: var(--text-soft);
         margin-bottom: 1rem;
     }
-    
+
     .coming-soon p {
-        color: var(--text-light);
+        color: var(--muted);
         font-style: italic;
     }
-    
+
     /* No Results */
     .no-results {
         text-align: center;
         padding: 3rem;
-        color: var(--text-light);
+        color: var(--muted);
         display: none;
     }
     
@@ -697,7 +739,7 @@
     <h2>About Our Analysis</h2>
     <p>Our threat intelligence analysis goes beyond automated reporting to provide deep technical insights into emerging attack patterns, obfuscation techniques, and defensive strategies. Each analysis includes:</p>
     
-    <ul style="margin-left: 2rem; color: var(--text-light);">
+    <ul style="margin-left: 2rem; color: var(--text-soft);">
         <li><strong>Technical Deep Dives:</strong> Detailed examination of attack methodologies and code analysis</li>
         <li><strong>Threat Actor Profiling:</strong> Infrastructure analysis and campaign attribution</li>
         <li><strong>Defensive Strategies:</strong> Actionable recommendations and detection rules</li>
@@ -835,7 +877,7 @@ function handleNewsletterSubmit(event) {
     // If they come back to the page with ?subscribed=true, show success
     if (window.location.search.includes('subscribed=true')) {
         submitBtn.textContent = '✓ Subscribed!';
-        submitBtn.style.background = '#22c55e';
+        submitBtn.style.background = 'var(--accent)';
         setTimeout(() => {
             submitBtn.textContent = 'Subscribe';
             submitBtn.style.background = '';

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,15 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}ClickGrab - Clipboard Attack Detection{% endblock %}</title>
     <meta name="description" content="ClickGrab analyzes potential ClickFix and FakeCAPTCHA URLs from URLhaus">
+    <meta name="theme-color" content="#0a0a0f">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ base_url }}/assets/css/styles.css">
     <link rel="icon" href="{{ base_url }}/assets/images/favicon.ico" type="image/x-icon">
-    <style>
-        .text-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: #0f766e;
-        }
-    </style>
     {% block head_extra %}{% endblock %}
 </head>
 <body>

--- a/templates/blog_post.html
+++ b/templates/blog_post.html
@@ -8,20 +8,23 @@
     .article-container {
         max-width: 900px;
         margin: 0 auto;
-        background: white;
-        border-radius: 12px;
-        box-shadow: var(--shadow-lg);
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
         overflow: hidden;
     }
-    
+
     .article-header {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: linear-gradient(135deg, var(--surface-2) 0%, var(--surface-3) 100%);
+        color: var(--text);
+        border-bottom: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
         padding: 3rem 2rem;
         text-align: center;
         position: relative;
     }
-    
+
     .article-header::before {
         content: '';
         position: absolute;
@@ -29,23 +32,26 @@
         left: 0;
         right: 0;
         bottom: 0;
-        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="20" cy="20" r="2" fill="rgba(255,255,255,0.1)"/><circle cx="80" cy="40" r="1.5" fill="rgba(255,255,255,0.1)"/><circle cx="40" cy="60" r="1" fill="rgba(255,255,255,0.1)"/><circle cx="70" cy="80" r="2.5" fill="rgba(255,255,255,0.1)"/></svg>') repeat;
+        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="20" cy="20" r="2" fill="rgba(0,255,136,0.12)"/><circle cx="80" cy="40" r="1.5" fill="rgba(0,255,136,0.12)"/><circle cx="40" cy="60" r="1" fill="rgba(0,255,136,0.12)"/><circle cx="70" cy="80" r="2.5" fill="rgba(0,255,136,0.12)"/></svg>') repeat;
         pointer-events: none;
     }
-    
+
     .article-header .content {
         position: relative;
         z-index: 1;
     }
-    
+
     .article-title {
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1.5px;
         font-size: 2.5rem;
         margin-bottom: 1rem;
         line-height: 1.2;
         border-bottom: none;
-        color: white;
+        color: var(--accent);
     }
-    
+
     .article-meta {
         display: flex;
         justify-content: center;
@@ -60,22 +66,26 @@
         margin-top: 1.25rem;
     }
     .hero-metric {
-        background: rgba(255,255,255,0.15);
-        border: 1px solid rgba(255,255,255,0.25);
-        color: white;
-        border-radius: 10px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
+        border-radius: var(--border-radius);
         padding: 0.75rem 1rem;
     }
-    .hero-metric .num { font-weight: 800; font-size: 1.4rem; display:block; }
-    .hero-metric .lbl { opacity: 0.95; font-size: 0.8rem; }
-    
+    .hero-metric .num { font-family: var(--font-mono); font-weight: 700; font-size: 1.4rem; display:block; color: var(--accent); }
+    .hero-metric .lbl { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 1px; color: var(--muted); font-size: 0.8rem; }
+
     .meta-item {
-        background: rgba(255,255,255,0.2);
+        font-family: var(--font-mono);
+        background: var(--surface);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
         padding: 0.5rem 1rem;
-        border-radius: 25px;
+        border-radius: 999px;
         font-size: 0.9rem;
     }
-    
+
     .article-content {
         padding: 3rem;
         line-height: 1.8;
@@ -85,189 +95,215 @@
     .toc-layout { display: grid; grid-template-columns: 1fr 260px; gap: 2rem; }
     .toc-sidebar {
         position: sticky; top: 100px; align-self: start; height: max-content;
-        background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 12px; padding: 1rem;
+        background: var(--surface-2); border: 1px solid var(--border);
+        border-left: 3px solid var(--accent); border-radius: var(--border-radius); padding: 1rem;
     }
-    .toc-title { font-weight: 700; margin: 0 0 0.5rem 0; font-size: 0.95rem; color: #334155; }
+    .toc-title { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 1px; font-weight: 700; margin: 0 0 0.5rem 0; font-size: 0.95rem; color: var(--accent); }
     .toc-list { list-style: none; margin: 0; padding: 0; }
     .toc-list li { margin: 0.25rem 0; }
-    .toc-link { color: #64748b; text-decoration: none; font-size: 0.9rem; }
-    .toc-link.active { color: #4f46e5; font-weight: 600; }
-    
+    .toc-link { color: var(--muted); text-decoration: none; font-size: 0.9rem; transition: color 0.18s ease; }
+    .toc-link:hover { color: var(--text-soft); }
+    .toc-link.active { color: var(--accent); font-weight: 600; }
+
     .article-content h2 {
-        color: var(--primary-color);
+        color: var(--accent);
         margin-top: 3rem;
         margin-bottom: 1.5rem;
         font-size: 1.8rem;
-        border-bottom: 2px solid var(--primary-color);
+        border-bottom: 1px solid var(--border);
         padding-bottom: 0.5rem;
     }
-    
+
     .article-content h3 {
-        color: var(--secondary-color);
+        color: var(--accent3);
         margin-top: 2rem;
         margin-bottom: 1rem;
         font-size: 1.4rem;
     }
-    
+
     .article-content h4 {
-        color: var(--text-color);
+        color: var(--text);
         margin-top: 1.5rem;
         margin-bottom: 0.75rem;
         font-size: 1.2rem;
     }
-    
+
     .article-content p {
         margin-bottom: 1.5rem;
-        color: var(--text-color);
+        color: var(--text-soft);
     }
-    
+
     .article-content ul, .article-content ol {
         margin-bottom: 1.5rem;
         padding-left: 2rem;
     }
-    
+
     .article-content li {
         margin-bottom: 0.5rem;
-        color: var(--text-color);
+        color: var(--text-soft);
     }
-    
+
     .article-content table {
         width: 100%;
         border-collapse: collapse;
         margin: 2rem 0;
-        background: #f8fafc;
-        border-radius: 8px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         overflow: hidden;
     }
-    
+
     .article-content th,
     .article-content td {
         padding: 1rem;
         text-align: left;
-        border-bottom: 1px solid #e2e8f0;
+        border-bottom: 1px solid var(--border);
+        color: var(--text-soft);
     }
-    
+
     .article-content th {
-        background: var(--primary-color);
-        color: white;
+        background: var(--surface-2);
+        color: var(--accent);
+        border-bottom: 2px solid var(--accent);
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         font-weight: 600;
     }
-    
+
     .article-content tr:hover {
-        background: #f1f5f9;
+        background: var(--highlight);
     }
-    
+
     .article-content pre {
-        background: #1a202c;
-        color: #e2e8f0;
+        background: #05050a;
+        color: var(--text-soft);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
         padding: 1.5rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         overflow-x: auto;
         margin: 1.5rem 0;
         line-height: 1.6;
+        font-family: var(--font-mono);
     }
-    
+
     .article-content code {
-        background: #f1f5f9;
-        color: #e53e3e;
+        background: var(--surface-3);
+        color: var(--accent3);
         padding: 0.25rem 0.5rem;
-        border-radius: 4px;
-        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+        border-radius: var(--border-radius);
+        font-family: var(--font-mono);
         font-size: 0.9em;
     }
-    
+
     .article-content pre code {
         background: none;
         color: inherit;
         padding: 0;
     }
-    
+
     .highlight-box {
-        background: linear-gradient(135deg, #fff5f5 0%, #fed7d7 100%);
-        border-left: 4px solid #e53e3e;
+        background: var(--surface-2);
+        border-left: 4px solid var(--accent2);
         padding: 1.5rem;
         margin: 2rem 0;
-        border-radius: 0 8px 8px 0;
+        border-radius: 0 var(--border-radius) var(--border-radius) 0;
+        color: var(--text-soft);
     }
-    
+
     .info-box {
-        background: linear-gradient(135deg, #ebf8ff 0%, #bee3f8 100%);
-        border-left: 4px solid var(--primary-color);
+        background: var(--surface-2);
+        border-left: 4px solid var(--accent3);
         padding: 1.5rem;
         margin: 2rem 0;
-        border-radius: 0 8px 8px 0;
+        border-radius: 0 var(--border-radius) var(--border-radius) 0;
+        color: var(--text-soft);
     }
-    
+
     .stats-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
         gap: 1.5rem;
         margin: 2rem 0;
     }
-    
+
     .stat-item {
-        background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         text-align: center;
     }
-    
+
     .stat-number {
+        font-family: var(--font-mono);
         font-size: 2rem;
         font-weight: 700;
+        color: var(--accent);
         display: block;
         margin-bottom: 0.5rem;
     }
-    
+
     .stat-label {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         font-size: 0.9rem;
-        opacity: 0.9;
+        color: var(--muted);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: var(--primary-color);
+        font-family: var(--font-mono);
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
         margin-bottom: 2rem;
-        transition: all 0.3s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .back-link:hover {
         transform: translateX(-5px);
+        color: var(--accent-dim);
     }
-    
+
     .article-footer {
-        background: #f8fafc;
+        background: var(--surface-2);
         padding: 2rem;
-        border-top: 1px solid #e2e8f0;
+        border-top: 1px solid var(--border);
         text-align: center;
+        color: var(--text-soft);
     }
-    
+
     .share-buttons {
         display: flex;
         justify-content: center;
         gap: 1rem;
         margin-top: 1rem;
     }
-    
+
     .share-btn-footer {
-        background: var(--primary-color);
-        color: white;
+        font-family: var(--font-mono);
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent);
         padding: 0.75rem 1.5rem;
-        border-radius: 25px;
+        border-radius: 999px;
         text-decoration: none;
         font-weight: 600;
-        transition: all 0.3s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .share-btn-footer:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(37, 99, 235, 0.3);
-        color: white;
+        border-color: var(--accent);
+        box-shadow: var(--shadow);
+        color: var(--accent);
     }
     
     @media (max-width: 768px) {

--- a/templates/css/styles.css
+++ b/templates/css/styles.css
@@ -1,280 +1,289 @@
-/* ClickGrab Styles */
+/* =========================================================================
+   ClickGrab — "Hunt in the Dark" design system
+   Hacker-terminal aesthetic, aligned with the BSides deck:
+   JetBrains Mono / Bebas Neue / Inter, near-black canvas, neon-green accent.
+   Fonts are loaded via <link> in base.html.
+   ========================================================================= */
+
 :root {
-    --primary-color: #0e7490;
-    --secondary-color: #0f766e;
-    --accent-color: #22c55e;
-    --text-color: #0f172a;
-    --text-light: #475569;
-    --background-color: #f4f8fb;
-    --danger-color: #ef4444;
-    --warning-color: #f59e0b;
-    --success-color: #22c55e;
-    --border-radius: 10px;
-    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-    --shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
-    --shadow-lg: 0 16px 36px rgba(15, 23, 42, 0.12);
+    /* --- Core palette (from the deck) --- */
+    --bg: #0a0a0f;
+    --surface: #0f0f1a;
+    --surface-2: #13131f;
+    --surface-3: #181826;
+    --border: #1e1e35;
+    --border-soft: #181830;
+
+    --accent: #00ff88;        /* neon green   */
+    --accent-dim: #00cc6a;
+    --accent2: #ff3366;       /* alert red    */
+    --accent3: #3d9eff;       /* info blue    */
+    --accent4: #ffcc00;       /* warning gold */
+
+    --text: #e8e8f0;
+    --text-soft: #c8c8d8;
+    --muted: #6b6b8a;
+    --highlight: rgba(0, 255, 136, 0.08);
+
+    /* --- Back-compat aliases (old templates reference these var names) --- */
+    --primary-color: var(--accent);
+    --secondary-color: var(--accent-dim);
+    --accent-color: var(--accent);
+    --text-color: var(--text);
+    --text-light: var(--muted);
+    --background-color: var(--bg);
+    --danger-color: var(--accent2);
+    --warning-color: var(--accent4);
+    --success-color: var(--accent);
+
+    --border-radius: 4px;
+    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.4);
+    --shadow: 0 12px 30px rgba(0, 0, 0, 0.5);
+    --shadow-lg: 0 20px 50px rgba(0, 0, 0, 0.6);
+
     --font-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    --font-display: 'Bebas Neue', 'Inter', sans-serif;
 }
 
-/* Base styles */
-* {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { scroll-behavior: smooth; }
 
 body {
     font-family: var(--font-sans);
-    line-height: 1.6;
-    color: var(--text-color);
-    background: linear-gradient(180deg, #f8fbfe 0%, var(--background-color) 280px);
+    line-height: 1.65;
+    color: var(--text);
+    background: var(--bg);
     font-size: 16px;
+    position: relative;
+    min-height: 100vh;
+    overflow-x: hidden;
+}
+
+/* Fixed background layers — grid + scanlines + glow, on every page */
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: -2;
+    background-image:
+        linear-gradient(rgba(0, 255, 136, 0.035) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(0, 255, 136, 0.035) 1px, transparent 1px);
+    background-size: 42px 42px;
+    pointer-events: none;
+}
+body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: -2;
+    background:
+        radial-gradient(620px circle at 12% -5%, rgba(0, 255, 136, 0.10), transparent 60%),
+        radial-gradient(560px circle at 92% 0%, rgba(61, 158, 255, 0.10), transparent 55%);
+    pointer-events: none;
 }
 
 a {
-    color: var(--primary-color);
+    color: var(--accent);
     text-decoration: none;
-    transition: color 0.2s ease, transform 0.2s ease;
+    transition: color 0.18s ease, opacity 0.18s ease;
 }
-
-a:hover {
-    color: var(--secondary-color);
-}
+a:hover { color: var(--accent3); }
 
 .container {
-    width: 90%;
+    width: 92%;
     max-width: 1200px;
     margin: 0 auto;
     padding: 0 15px;
 }
 
-/* Typography */
+/* ---------------------------------------------------------------- Typography */
 h1, h2, h3, h4, h5, h6 {
     margin-bottom: 1rem;
-    color: var(--text-color);
+    color: var(--text);
     font-weight: 700;
-    line-height: 1.2;
+    line-height: 1.15;
+    letter-spacing: 0.3px;
 }
 
 h1 {
-    font-size: 2.25rem;
-    border-bottom: 2px solid var(--primary-color);
-    padding-bottom: 0.75rem;
-    margin-bottom: 1.5rem;
+    font-family: var(--font-display);
+    font-size: clamp(2.2rem, 4.4vw, 3.4rem);
+    letter-spacing: 3px;
+    font-weight: 400;
+    padding-bottom: 0.6rem;
+    margin-bottom: 1.4rem;
+    border-bottom: 1px solid var(--border);
+}
+h1::after {
+    content: '';
+    display: block;
+    width: 64px;
+    height: 2px;
+    margin-top: 0.6rem;
+    background: var(--accent);
+    box-shadow: 0 0 10px var(--accent);
 }
 
-h2 {
-    font-size: 1.875rem;
-    margin-top: 2rem;
-}
+h2 { font-size: 1.75rem; margin-top: 2rem; }
+h3 { font-size: 1.35rem; }
 
-h3 {
-    font-size: 1.5rem;
-}
+p { margin-bottom: 1.2rem; color: var(--text-soft); }
 
-p {
-    margin-bottom: 1.25rem;
-    color: var(--text-light);
-}
+code, pre, kbd, samp { font-family: var(--font-mono); }
 
-/* Header styles */
+/* selection */
+::selection { background: rgba(0, 255, 136, 0.25); color: #fff; }
+
+/* scrollbar */
+::-webkit-scrollbar { width: 11px; height: 11px; }
+::-webkit-scrollbar-track { background: var(--surface); }
+::-webkit-scrollbar-thumb { background: #25254a; border-radius: 6px; }
+::-webkit-scrollbar-thumb:hover { background: #32325f; }
+
+/* ----------------------------------------------------------------- Header */
 .site-header {
-    background-color: rgba(255, 255, 255, 0.92);
-    backdrop-filter: blur(10px);
-    box-shadow: 0 1px 0 rgba(15, 23, 42, 0.06);
-    border-bottom: 1px solid #e2e8f0;
-    padding: 1rem 0;
+    background: rgba(10, 10, 15, 0.82);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border);
+    padding: 0.9rem 0;
     position: sticky;
     top: 0;
     z-index: 100;
 }
-
 .site-header .container {
     display: flex;
     justify-content: space-between;
     align-items: center;
 }
-
 .logo a {
     display: flex;
     align-items: center;
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: var(--primary-color);
+    font-family: var(--font-display);
+    font-size: 1.6rem;
+    letter-spacing: 3px;
+    font-weight: 400;
+    color: var(--accent);
     text-decoration: none;
+    text-shadow: 0 0 18px rgba(0, 255, 136, 0.4);
+}
+.logo img { height: 38px; margin-right: 12px; }
+
+.text-logo {
+    font-family: var(--font-display);
+    font-size: 1.6rem;
+    letter-spacing: 3px;
+    font-weight: 400;
+    color: var(--accent);
+    text-shadow: 0 0 18px rgba(0, 255, 136, 0.4);
 }
 
-.logo img {
-    height: 40px;
-    margin-right: 12px;
-}
-
-.main-nav ul {
-    display: flex;
-    list-style: none;
-    gap: 1.5rem;
-}
-
+.main-nav ul { display: flex; list-style: none; gap: 0.4rem; }
 .main-nav a {
     text-decoration: none;
-    color: var(--text-color);
+    color: var(--text-soft);
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    letter-spacing: 1px;
+    text-transform: uppercase;
     font-weight: 500;
-    padding: 0.5rem 0.75rem;
+    padding: 0.5rem 0.85rem;
+    border: 1px solid transparent;
     border-radius: var(--border-radius);
-    transition: background-color 0.2s ease, color 0.2s ease;
+    transition: all 0.18s ease;
 }
-
 .main-nav a:hover {
-    background-color: #e0f2fe;
-    color: var(--primary-color);
+    color: var(--accent);
+    border-color: var(--border);
+    background: var(--highlight);
 }
-
 .main-nav a.active {
-    color: var(--primary-color);
-    background-color: #dbeafe;
-    font-weight: 600;
+    color: var(--accent);
+    border-color: rgba(0, 255, 136, 0.4);
+    background: var(--highlight);
 }
 
-/* Main content */
-.site-content {
-    padding: 2rem 0;
-}
+/* --------------------------------------------------------------- Content */
+.site-content { padding: 2.5rem 0 3rem; }
 
-/* Hero section */
+/* ----------------------------------------------------------------- Hero (legacy) */
 .hero {
-    background: linear-gradient(to right, var(--primary-color), var(--secondary-color));
-    color: white;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-top: 3px solid var(--accent);
+    color: var(--text);
     text-align: center;
     padding: 4rem 2rem;
     border-radius: var(--border-radius);
     margin-bottom: 2rem;
     box-shadow: var(--shadow);
 }
-
-.hero h1 {
-    font-size: 2.5rem;
-    margin-bottom: 1rem;
-    border-bottom: none;
-    color: white;
-}
-
+.hero h1 { border-bottom: none; color: var(--text); }
+.hero h1::after { margin-left: auto; margin-right: auto; }
 .subtitle {
-    font-size: 1.25rem;
+    font-size: 1.2rem;
     max-width: 800px;
     margin: 0 auto 2rem;
-    color: rgba(255, 255, 255, 0.9);
+    color: var(--text-soft);
 }
 
 .stats-overview {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 2rem;
-    margin-bottom: 2rem;
+    display: flex; flex-wrap: wrap; justify-content: center;
+    gap: 1.5rem; margin-bottom: 2rem;
 }
-
 .stat-card {
-    background-color: rgba(255, 255, 255, 0.1);
-    backdrop-filter: blur(5px);
-    padding: 1.5rem;
-    border-radius: var(--border-radius);
-    min-width: 180px;
-    transition: transform 0.3s ease;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    padding: 1.5rem; border-radius: var(--border-radius);
+    min-width: 180px; transition: transform 0.25s ease, border-color 0.25s ease;
 }
+.stat-card:hover { transform: translateY(-4px); border-color: var(--accent); }
+.stat-number { font-family: var(--font-display); font-size: 2.6rem; letter-spacing: 2px; color: var(--accent); margin-bottom: 0.4rem; }
+.stat-label { font-family: var(--font-mono); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 2px; color: var(--muted); }
 
-.stat-card:hover {
-    transform: translateY(-5px);
-}
+.cta-buttons { display: flex; justify-content: center; gap: 1rem; flex-wrap: wrap; }
 
-.stat-number {
-    font-size: 2.5rem;
-    font-weight: 700;
-    margin-bottom: 0.5rem;
-}
-
-.stat-label {
-    font-size: 0.875rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-}
-
-.cta-buttons {
-    display: flex;
-    justify-content: center;
-    gap: 1rem;
-    flex-wrap: wrap;
-}
-
-/* Buttons */
+/* ----------------------------------------------------------------- Buttons */
 .btn {
     display: inline-block;
-    background-color: var(--primary-color);
-    color: white;
-    padding: 0.75rem 1.5rem;
+    background: var(--surface-2);
+    color: var(--text);
+    padding: 0.7rem 1.4rem;
+    border: 1px solid var(--border);
     border-radius: var(--border-radius);
     text-decoration: none;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    letter-spacing: 1px;
     font-weight: 600;
-    transition: background-color 0.2s ease, transform 0.2s ease;
-    box-shadow: var(--shadow-sm);
+    transition: all 0.18s ease;
+    cursor: pointer;
 }
-
 .btn:hover {
-    background-color: var(--secondary-color);
-    color: white;
+    color: var(--accent);
+    border-color: var(--accent);
+    background: var(--highlight);
     transform: translateY(-2px);
-    box-shadow: var(--shadow);
 }
-
 .btn.primary {
-    background-color: white;
-    color: var(--primary-color);
+    background: var(--accent);
+    color: #05140d;
+    border-color: var(--accent);
+    box-shadow: 0 0 22px rgba(0, 255, 136, 0.25);
 }
+.btn.primary:hover { background: var(--accent-dim); color: #05140d; }
+.btn.secondary { background: var(--surface-2); color: var(--text-soft); }
+.btn.secondary:hover { color: var(--accent3); border-color: var(--accent3); }
+.btn.small, .btn-small { padding: 0.4rem 0.9rem; font-size: 0.78rem; }
+.btn.outline, .btn-outline { background: transparent; border: 1px solid var(--accent); color: var(--accent); }
+.btn.outline:hover, .btn-outline:hover { background: var(--accent); color: #05140d; }
 
-.btn.primary:hover {
-    background-color: rgba(255, 255, 255, 0.9);
-    color: var(--secondary-color);
-}
-
-.btn.secondary {
-    background-color: rgba(14, 116, 144, 0.1);
-    color: white;
-    border: 1px solid rgba(14, 116, 144, 0.4);
-}
-
-.btn.secondary:hover {
-    background-color: rgba(14, 116, 144, 0.18);
-}
-
-.btn.small {
-    padding: 0.5rem 1rem;
-    font-size: 0.875rem;
-}
-
-.btn.outline {
-    background-color: transparent;
-    border: 1px solid var(--primary-color);
-    color: var(--primary-color);
-}
-
-.btn.outline:hover {
-    background-color: var(--primary-color);
-    color: white;
-}
-
-.btn-outline {
-    background-color: transparent;
-    border: 1px solid var(--primary-color);
-    color: var(--primary-color);
-}
-
-.btn-outline:hover {
-    background-color: var(--primary-color);
-    color: white;
-}
-
-/* Sections */
-.latest-findings, .about-project {
-    background-color: white;
+/* ----------------------------------------------------------- Generic cards */
+.latest-findings, .about-project, .technical-analysis {
+    background: var(--surface);
+    border: 1px solid var(--border);
     padding: 2rem;
     border-radius: var(--border-radius);
     margin-bottom: 2rem;
@@ -282,615 +291,238 @@ p {
 }
 
 .report-summary {
-    border-left: 4px solid var(--primary-color);
+    border-left: 3px solid var(--accent);
     padding: 1.5rem;
-    background-color: rgba(37, 99, 235, 0.05);
+    background: var(--highlight);
     border-radius: 0 var(--border-radius) var(--border-radius) 0;
-}
-
-.mini-stats {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 2rem;
-    margin: 1.5rem 0;
-}
-
-.mini-stat {
-    flex: 1;
-    min-width: 200px;
-}
-
-.mini-stat .label {
-    display: block;
-    margin-bottom: 0.5rem;
-    color: var(--text-light);
-}
-
-.mini-stat .value {
-    font-size: 1.75rem;
-    font-weight: 700;
-    color: var(--primary-color);
-}
-
-.alert {
-    padding: 1rem;
-    border-radius: var(--border-radius);
-    margin-bottom: 1.5rem;
-}
-
-.alert.warning {
-    background-color: rgba(245, 158, 11, 0.1);
-    border-left: 4px solid var(--warning-color);
-    color: #92400e;
-}
-
-/* Report page styles */
-.page-header {
     margin-bottom: 2rem;
 }
 
-.report-actions {
-    display: flex;
-    gap: 1rem;
-    margin-top: 1rem;
-}
+.mini-stats { display: flex; flex-wrap: wrap; gap: 2rem; margin: 1.5rem 0; }
+.mini-stat { flex: 1; min-width: 200px; }
+.mini-stat .label { display: block; margin-bottom: 0.5rem; color: var(--muted); font-family: var(--font-mono); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 1px; }
+.mini-stat .value { font-family: var(--font-display); font-size: 1.9rem; letter-spacing: 1px; color: var(--accent); }
 
-.report-summary {
-    margin-bottom: 2rem;
-}
+.alert { padding: 1rem 1.25rem; border-radius: var(--border-radius); margin-bottom: 1.5rem; border: 1px solid var(--border); }
+.alert.warning { background: rgba(255, 204, 0, 0.08); border-left: 3px solid var(--warning-color); color: #ffe08a; }
 
-.summary-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1.5rem;
-}
+/* -------------------------------------------------------- Report summary grid */
+.page-header { margin-bottom: 2rem; }
+.report-actions { display: flex; gap: 1rem; margin-top: 1rem; flex-wrap: wrap; }
 
+.summary-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1.25rem; }
 .summary-card {
-    background-color: white;
-    padding: 1.5rem;
-    border-radius: var(--border-radius);
-    box-shadow: var(--shadow);
-    text-align: center;
-    transition: transform 0.3s ease;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 1.5rem; border-radius: var(--border-radius);
+    box-shadow: var(--shadow); text-align: center;
+    transition: transform 0.25s ease, border-color 0.25s ease;
 }
+.summary-card:hover { transform: translateY(-4px); border-color: var(--accent); }
+.summary-card h3 { font-family: var(--font-display); font-size: 2.6rem; letter-spacing: 1px; color: var(--accent); margin-bottom: 0.4rem; }
 
-.summary-card:hover {
-    transform: translateY(-5px);
-}
-
-.summary-card h3 {
-    font-size: 2.5rem;
-    color: var(--primary-color);
-    margin-bottom: 0.5rem;
-}
-
-/* Attack breakdown */
-.attack-breakdown {
-    margin-bottom: 2rem;
-}
-
-.breakdown-cards {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 1.5rem;
-}
-
+/* ------------------------------------------------------------ Attack breakdown */
+.attack-breakdown { margin-bottom: 2rem; }
+.breakdown-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.25rem; }
 .breakdown-card {
-    background-color: white;
-    padding: 1.5rem;
-    border-radius: var(--border-radius);
-    box-shadow: var(--shadow);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 1.5rem; border-radius: var(--border-radius); box-shadow: var(--shadow);
 }
+.stat-value { font-family: var(--font-display); font-size: 2.1rem; letter-spacing: 1px; color: var(--accent); margin-bottom: 0.5rem; }
 
-.stat-value {
-    font-size: 2rem;
-    font-weight: 700;
-    color: var(--primary-color);
-    margin-bottom: 0.5rem;
-}
+.progress-bar { height: 8px; background: var(--surface-3); border-radius: 999px; overflow: hidden; margin-bottom: 0.5rem; }
+.progress { height: 100%; background: linear-gradient(90deg, var(--accent-dim), var(--accent)); transition: width 1s ease-in-out; }
 
-.progress-bar {
-    height: 10px;
-    background-color: #e9ecef;
-    border-radius: 1rem;
-    overflow: hidden;
-    margin-bottom: 0.5rem;
-}
-
-.progress {
-    height: 100%;
-    background-color: var(--primary-color);
-    transition: width 1s ease-in-out;
-}
-
-/* Affected sites */
-.sites-list {
-    margin-bottom: 2rem;
-}
-
+/* ------------------------------------------------------------- Tables */
+.sites-list { margin-bottom: 2rem; }
 .sites-table-wrapper {
     overflow-x: auto;
-    background-color: white;
+    background: var(--surface);
+    border: 1px solid var(--border);
     border-radius: var(--border-radius);
     box-shadow: var(--shadow);
 }
-
-.sites-table {
-    width: 100%;
-    border-collapse: collapse;
-}
-
-.sites-table th,
-.sites-table td {
-    padding: 1rem;
-    text-align: left;
-    border-bottom: 1px solid #e5e7eb;
-}
-
+.sites-table { width: 100%; border-collapse: collapse; font-size: 0.92rem; }
+.sites-table th, .sites-table td { padding: 0.9rem 1rem; text-align: left; border-bottom: 1px solid var(--border); }
 .sites-table th {
-    background-color: #f9fafb;
-    font-weight: 600;
+    background: var(--surface-2);
+    font-family: var(--font-mono);
+    font-size: 0.74rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--accent);
+    border-bottom: 2px solid var(--accent);
 }
+.sites-table tr:last-child td { border-bottom: none; }
+.sites-table tbody tr { transition: background 0.15s ease; }
+.sites-table tbody tr:hover { background: var(--highlight); }
 
-.sites-table tr:last-child td {
-    border-bottom: none;
-}
-
-.sites-table tr:hover {
-    background-color: #f9fafb;
-}
-
-/* Technical analysis */
-.technical-analysis {
-    background-color: white;
-    padding: 2rem;
-    border-radius: var(--border-radius);
-    box-shadow: var(--shadow);
-}
-
-.analysis-content {
-    line-height: 1.7;
-}
-
-.analysis-content h2 {
-    margin-top: 2rem;
-    margin-bottom: 1rem;
-    font-size: 1.5rem;
-}
-
-.analysis-content ul,
-.analysis-content ol {
-    margin-left: 1.5rem;
-    margin-bottom: 1.5rem;
-}
-
-.analysis-content p {
-    margin-bottom: 1.25rem;
-}
-
+/* ------------------------------------------------------ Analysis prose */
+.analysis-content { line-height: 1.75; }
+.analysis-content h2 { margin-top: 2rem; margin-bottom: 1rem; font-size: 1.5rem; color: var(--text); }
+.analysis-content ul, .analysis-content ol { margin-left: 1.5rem; margin-bottom: 1.5rem; }
+.analysis-content p { margin-bottom: 1.2rem; }
 .analysis-content pre {
-    background-color: #f9fafb;
-    padding: 1.25rem;
-    border-radius: var(--border-radius);
-    overflow-x: auto;
-    margin-bottom: 1.25rem;
-    border: 1px solid #e5e7eb;
+    background: #05050a;
+    padding: 1.2rem; border-radius: var(--border-radius);
+    overflow-x: auto; margin-bottom: 1.2rem;
+    border: 1px solid var(--border); border-left: 3px solid var(--accent);
+    font-size: 0.86rem; line-height: 1.6;
 }
-
-.analysis-content code {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-    background-color: #f9fafb;
-    padding: 0.125rem 0.25rem;
-    border-radius: 0.25rem;
-    font-size: 0.875em;
-    border: 1px solid #e5e7eb;
+.analysis-content code, code {
+    font-family: var(--font-mono);
+    background: var(--surface-3);
+    padding: 0.12rem 0.4rem; border-radius: 4px;
+    font-size: 0.86em; color: var(--accent3);
+    border: 1px solid var(--border);
 }
+.analysis-content pre code { background: none; border: none; padding: 0; color: var(--text-soft); }
 
-/* Reports list page */
+/* ---------------------------------------------------- Reports list page */
 .report-filter {
-    background-color: white;
-    padding: 1.5rem;
-    border-radius: var(--border-radius);
-    margin-bottom: 2rem;
-    box-shadow: var(--shadow);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 1.5rem; border-radius: var(--border-radius);
+    margin-bottom: 2rem; box-shadow: var(--shadow);
 }
-
-.filter-controls {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1.5rem;
-}
-
-.filter-group {
-    flex: 1;
-    min-width: 200px;
-}
-
+.filter-controls { display: flex; flex-wrap: wrap; gap: 1.5rem; }
+.filter-group { flex: 1; min-width: 200px; }
 .filter-select {
-    width: 100%;
-    padding: 0.75rem;
+    width: 100%; padding: 0.7rem;
     border-radius: var(--border-radius);
-    border: 1px solid #e5e7eb;
-    background-color: white;
-    font-size: 1rem;
-    margin-top: 0.5rem;
+    border: 1px solid var(--border);
+    background: var(--surface-2); color: var(--text);
+    font-family: var(--font-mono); font-size: 0.9rem; margin-top: 0.5rem;
 }
+.year-group { margin-bottom: 3rem; }
+.month-group { margin-bottom: 2rem; }
 
-.year-group {
-    margin-bottom: 3rem;
-}
-
-.month-group {
-    margin-bottom: 2rem;
-}
-
-.reports-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    gap: 1.5rem;
-    margin-top: 1rem;
-}
-
+.reports-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.25rem; margin-top: 1rem; }
 .report-card {
-    background-color: white;
+    background: var(--surface);
+    border: 1px solid var(--border);
     border-radius: var(--border-radius);
-    padding: 1.5rem;
-    box-shadow: var(--shadow);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    padding: 1.5rem; box-shadow: var(--shadow);
+    transition: transform 0.25s ease, border-color 0.25s ease;
 }
+.report-card:hover { transform: translateY(-4px); border-color: var(--accent); box-shadow: var(--shadow-lg); }
+.report-date { color: var(--muted); font-family: var(--font-mono); font-size: 0.8rem; margin-bottom: 0.5rem; }
+.report-card h4 { font-size: 1.2rem; margin-bottom: 1rem; color: var(--text); }
+.report-stats { display: flex; gap: 1.5rem; margin-bottom: 1.5rem; }
+.report-stats .stat { flex: 1; }
+.report-stats .value { display: block; font-family: var(--font-display); font-size: 1.5rem; letter-spacing: 1px; color: var(--accent); margin-bottom: 0.25rem; }
+.report-stats .label { font-family: var(--font-mono); font-size: 0.7rem; text-transform: uppercase; letter-spacing: 1px; color: var(--muted); }
 
-.report-card:hover {
-    transform: translateY(-5px);
-    box-shadow: var(--shadow-lg);
-}
-
-.report-date {
-    color: var(--text-light);
-    font-size: 0.875rem;
-    margin-bottom: 0.5rem;
-}
-
-.report-card h4 {
-    font-size: 1.25rem;
-    margin-bottom: 1rem;
-}
-
-.report-stats {
-    display: flex;
-    gap: 1.5rem;
-    margin-bottom: 1.5rem;
-}
-
-.report-stats .stat {
-    flex: 1;
-}
-
-.report-stats .value {
-    display: block;
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: var(--primary-color);
-    margin-bottom: 0.25rem;
-}
-
-.report-stats .label {
-    font-size: 0.75rem;
-    color: var(--text-light);
-}
-
-.new-patterns {
-    margin-bottom: 1.5rem;
-    padding: 0.5rem 0.75rem;
-    background-color: rgba(245, 158, 11, 0.1);
-    border-radius: var(--border-radius);
-    font-size: 0.875rem;
-}
-
+.new-patterns { margin-bottom: 1.5rem; padding: 0.5rem 0.75rem; background: rgba(255, 204, 0, 0.08); border: 1px solid rgba(255, 204, 0, 0.25); border-radius: var(--border-radius); font-size: 0.85rem; }
 .badge {
-    display: inline-block;
-    background-color: var(--warning-color);
-    color: white;
-    padding: 0.125rem 0.375rem;
-    border-radius: 0.25rem;
-    font-weight: 600;
-    font-size: 0.75rem;
-    margin-right: 0.375rem;
+    display: inline-block; background: var(--accent4); color: #1a1500;
+    padding: 0.12rem 0.45rem; border-radius: 4px; font-weight: 700;
+    font-family: var(--font-mono); font-size: 0.7rem; margin-right: 0.375rem;
 }
 
 .view-report {
-    display: block;
-    text-align: center;
-    background-color: #f9fafb;
-    padding: 0.75rem;
-    border-radius: var(--border-radius);
-    font-weight: 500;
-    transition: background-color 0.2s;
+    display: block; text-align: center;
+    background: var(--surface-2); border: 1px solid var(--border);
+    padding: 0.7rem; border-radius: var(--border-radius);
+    font-family: var(--font-mono); font-size: 0.82rem; letter-spacing: 1px;
+    color: var(--accent); transition: all 0.18s;
 }
+.view-report:hover { background: var(--highlight); border-color: var(--accent); }
 
-.view-report:hover {
-    background-color: var(--primary-color);
-    color: white;
-}
-
-.pagination {
-    text-align: center;
-    margin-top: 3rem;
-}
-
+.pagination { text-align: center; margin-top: 3rem; }
 .pagination-btn {
-    background-color: white;
-    border: 1px solid #e5e7eb;
-    padding: 0.75rem 1.5rem;
-    border-radius: var(--border-radius);
-    font-size: 1rem;
-    cursor: pointer;
-    transition: background-color 0.2s, border-color 0.2s;
-    box-shadow: var(--shadow-sm);
+    background: var(--surface-2); border: 1px solid var(--border);
+    padding: 0.7rem 1.4rem; border-radius: var(--border-radius);
+    font-family: var(--font-mono); font-size: 0.9rem; color: var(--text);
+    cursor: pointer; transition: all 0.18s;
 }
+.pagination-btn:hover { border-color: var(--accent); color: var(--accent); }
 
-.pagination-btn:hover {
-    background-color: #f9fafb;
-    border-color: #d1d5db;
-}
-
-/* Footer styles */
+/* ---------------------------------------------------------------- Footer */
 .site-footer {
-    background-color: #0f172a;
-    color: white;
-    padding: 3rem 0;
-    margin-top: 3rem;
+    background: #06060a;
+    border-top: 1px solid var(--border);
+    color: var(--text-soft);
+    padding: 3rem 0 2rem;
+    margin-top: 4rem;
+    position: relative;
 }
-
-.footer-content {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 3rem;
+.site-footer::before {
+    content: '';
+    position: absolute; top: -1px; left: 0; right: 0; height: 1px;
+    background: linear-gradient(90deg, transparent, var(--accent), transparent);
+    opacity: 0.5;
 }
+.footer-content { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 3rem; }
+.footer-logo img { height: 38px; margin-bottom: 1rem; }
+.footer-logo p { color: var(--muted); font-size: 0.85rem; }
+.footer-links h3 { color: var(--text); margin-bottom: 1.1rem; font-family: var(--font-mono); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 2px; }
+.footer-links ul { list-style: none; }
+.footer-links li { margin-bottom: 0.7rem; }
+.footer-links a { color: var(--muted); font-size: 0.86rem; }
+.footer-links a:hover { color: var(--accent); }
+.footer-bottom { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--border); text-align: center; font-size: 0.82rem; color: var(--muted); }
 
-.footer-logo img {
-    height: 40px;
-    margin-bottom: 1rem;
-}
-
-.footer-logo p {
-    color: #9ca3af;
-    font-size: 0.875rem;
-}
-
-.footer-links h3 {
-    color: white;
-    margin-bottom: 1.25rem;
-    font-size: 1rem;
-}
-
-.footer-links ul {
-    list-style: none;
-}
-
-.footer-links li {
-    margin-bottom: 0.75rem;
-}
-
-.footer-links a {
-    color: #9ca3af;
-    text-decoration: none;
-    transition: color 0.2s ease;
-    font-size: 0.875rem;
-}
-
-.footer-links a:hover {
-    color: white;
-}
-
-.footer-bottom {
-    margin-top: 3rem;
-    padding-top: 1.5rem;
-    border-top: 1px solid #374151;
-    text-align: center;
-    font-size: 0.875rem;
-    color: #9ca3af;
-}
-
-/* Responsive styles */
-@media (max-width: 768px) {
-    .site-header .container {
-        flex-direction: column;
-    }
-    
-    .main-nav ul {
-        margin-top: 1rem;
-        justify-content: center;
-    }
-    
-    .hero h1 {
-        font-size: 1.875rem;
-    }
-    
-    .stat-card {
-        width: 100%;
-    }
-    
-    .footer-content {
-        grid-template-columns: 1fr;
-    }
-
-    .stats-overview {
-        flex-direction: column;
-        align-items: center;
-    }
-
-    .stat-card {
-        width: 80%;
-    }
-}
-
-/* Add styles for the detailed URL analysis section */
-.detailed-findings {
-  margin-top: 3rem;
-}
-
+/* ----------------------------------------------------- Detailed URL cards */
+.detailed-findings { margin-top: 3rem; }
 .url-analysis-card {
-  background-color: #fff;
-  border-radius: 8px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-  margin-bottom: 2rem;
-  overflow: hidden;
-  transition: box-shadow 0.3s ease;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius);
+    box-shadow: var(--shadow);
+    margin-bottom: 2rem; overflow: hidden;
+    transition: box-shadow 0.25s ease, border-color 0.25s ease;
 }
+.url-analysis-card.highlight { border-color: var(--accent4); box-shadow: 0 0 22px rgba(255, 204, 0, 0.25); }
+.url-header { background: var(--surface-2); padding: 1.4rem; border-bottom: 1px solid var(--border); }
+.url-header h3 { margin: 0 0 0.5rem 0; color: var(--text); word-break: break-all; }
+.url-meta { display: flex; gap: 1.5rem; font-family: var(--font-mono); font-size: 0.82rem; color: var(--muted); flex-wrap: wrap; }
+.url-type { background: rgba(61, 158, 255, 0.12); color: var(--accent3); border: 1px solid rgba(61, 158, 255, 0.3); border-radius: 4px; padding: 0.2rem 0.7rem; font-weight: 600; }
+.url-findings strong { color: var(--accent2); }
 
-.url-analysis-card.highlight {
-  box-shadow: 0 0 15px rgba(255, 165, 0, 0.7);
-}
-
-.url-header {
-  background-color: #f5f7fa;
-  padding: 1.5rem;
-  border-bottom: 1px solid #eaeef3;
-}
-
-.url-header h3 {
-  margin: 0 0 0.5rem 0;
-  color: #2c3e50;
-}
-
-.url-meta {
-  display: flex;
-  gap: 1.5rem;
-  font-size: 0.9rem;
-  color: #6c757d;
-}
-
-.url-type {
-  background-color: #e1f5fe;
-  color: #0277bd;
-  border-radius: 4px;
-  padding: 0.25rem 0.75rem;
-  font-weight: 500;
-}
-
-.url-findings strong {
-  color: #e74c3c;
-}
-
-.url-tabs {
-  display: flex;
-  background-color: #f8f9fa;
-  border-bottom: 1px solid #eaeef3;
-  padding: 0 1rem;
-}
-
+.url-tabs { display: flex; background: var(--surface-2); border-bottom: 1px solid var(--border); padding: 0 1rem; flex-wrap: wrap; }
 .tab-btn {
-  background: none;
-  border: none;
-  padding: 1rem 1.25rem;
-  cursor: pointer;
-  color: #6c757d;
-  font-weight: 500;
-  border-bottom: 2px solid transparent;
-  transition: all 0.2s ease;
+    background: none; border: none; padding: 0.9rem 1.2rem; cursor: pointer;
+    color: var(--muted); font-family: var(--font-mono); font-size: 0.82rem; font-weight: 500;
+    border-bottom: 2px solid transparent; transition: all 0.18s ease;
 }
+.tab-btn:hover { color: var(--accent3); }
+.tab-btn.active { color: var(--accent); border-bottom-color: var(--accent); }
+.tab-content { display: none; padding: 1.5rem; }
+.tab-content.active { display: block; }
 
-.tab-btn:hover {
-  color: #3498db;
+.code-block { background: #05050a; border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: var(--border-radius); overflow: hidden; margin-bottom: 1.5rem; }
+.code-block pre { margin: 0; padding: 1.2rem; font-family: var(--font-mono); font-size: 0.86rem; line-height: 1.6; overflow-x: auto; }
+.code-block code { background: none; padding: 0; color: var(--text-soft); border: none; }
+
+.findings-groups { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.25rem; }
+.findings-group { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius); padding: 1.2rem; }
+.findings-group h4 { margin-top: 0; margin-bottom: 1rem; color: var(--text); font-family: var(--font-mono); font-size: 0.92rem; text-transform: uppercase; letter-spacing: 1px; }
+.findings-group ul { margin: 0; padding: 0; list-style: none; }
+.findings-group li { margin-bottom: 0.75rem; }
+.findings-group code { background: var(--surface-3); padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.82rem; color: var(--accent3); border: 1px solid var(--border); word-break: break-all; display: inline-block; max-width: 100%; }
+
+.malicious-url { color: var(--accent2); text-decoration: none; word-break: break-all; }
+.malicious-url:hover { text-decoration: underline; }
+
+/* ------------------------------------------------------------ Utilities */
+.mono { font-family: var(--font-mono); }
+.glow-green { text-shadow: 0 0 18px rgba(0, 255, 136, 0.5); }
+.text-accent { color: var(--accent); }
+.text-red { color: var(--accent2); }
+.text-blue { color: var(--accent3); }
+.text-gold { color: var(--accent4); }
+
+@keyframes blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
+.cursor::after { content: '_'; animation: blink 1s step-end infinite; color: var(--accent); }
+
+/* ----------------------------------------------------------- Responsive */
+@media (max-width: 768px) {
+    .site-header .container { flex-direction: column; gap: 0.8rem; }
+    .main-nav ul { flex-wrap: wrap; justify-content: center; }
+    .footer-content { grid-template-columns: 1fr; }
+    .stats-overview { flex-direction: column; align-items: center; }
+    .stat-card { width: 100%; }
+    .report-stats { flex-wrap: wrap; }
 }
-
-.tab-btn.active {
-  color: #2c3e50;
-  border-bottom-color: #3498db;
-}
-
-.tab-content {
-  display: none;
-  padding: 1.5rem;
-}
-
-.tab-content.active {
-  display: block;
-}
-
-.code-block {
-  background-color: #f8f9fb;
-  border-radius: 6px;
-  overflow: hidden;
-  margin-bottom: 1.5rem;
-}
-
-.code-block pre {
-  margin: 0;
-  padding: 1.25rem;
-  font-family: 'Monaco', 'Consolas', monospace;
-  font-size: 0.9rem;
-  line-height: 1.5;
-  overflow-x: auto;
-}
-
-.code-block code {
-  background: none;
-  padding: 0;
-  color: #333;
-}
-
-.findings-groups {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 1.5rem;
-}
-
-.findings-group {
-  background-color: #f8f9fb;
-  border-radius: 6px;
-  padding: 1.25rem;
-}
-
-.findings-group h4 {
-  margin-top: 0;
-  margin-bottom: 1rem;
-  color: #2c3e50;
-  font-size: 1rem;
-}
-
-.findings-group ul {
-  margin: 0;
-  padding: 0;
-  list-style-type: none;
-}
-
-.findings-group li {
-  margin-bottom: 0.75rem;
-}
-
-.findings-group code {
-  background-color: #f1f3f5;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  font-size: 0.85rem;
-  word-break: break-all;
-  display: inline-block;
-  max-width: 100%;
-  overflow-x: auto;
-}
-
-.malicious-url {
-  color: #e74c3c;
-  text-decoration: none;
-  word-break: break-all;
-}
-
-.malicious-url:hover {
-  text-decoration: underline;
-}
-
-.btn-small {
-  display: inline-block;
-  padding: 0.25rem 0.75rem;
-  font-size: 0.85rem;
-  background-color: #3498db;
-  color: white;
-  border-radius: 4px;
-  text-decoration: none;
-  transition: background-color 0.2s ease;
-}
-
-.btn-small:hover {
-  background-color: #2980b9;
-} 

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,471 +4,300 @@
 
 {% block head_extra %}
 <style>
+    /* ---- Hero ------------------------------------------------------ */
     .intel-hero {
-        background: linear-gradient(140deg, #082f49 0%, #0f766e 55%, #0891b2 100%);
-        color: #e2f2ff;
-        border-radius: 20px;
-        padding: 3.5rem 2.25rem;
+        background:
+            linear-gradient(135deg, var(--surface) 0%, var(--surface-2) 100%);
+        color: var(--text);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        border-radius: var(--border-radius);
+        padding: 3.25rem 2.25rem;
         margin-bottom: 2.5rem;
-        box-shadow: 0 18px 45px rgba(8, 47, 73, 0.25);
+        box-shadow: var(--shadow);
         position: relative;
         overflow: hidden;
     }
-
+    .intel-hero::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-image:
+            linear-gradient(rgba(0,255,136,0.04) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(0,255,136,0.04) 1px, transparent 1px);
+        background-size: 34px 34px;
+        pointer-events: none;
+    }
     .intel-hero::after {
         content: '';
         position: absolute;
         inset: 0;
         background:
-            radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.14), transparent 36%),
-            radial-gradient(circle at 82% 8%, rgba(207, 250, 254, 0.2), transparent 34%);
+            radial-gradient(circle at 12% 12%, rgba(0, 255, 136, 0.16), transparent 38%),
+            radial-gradient(circle at 88% 4%, rgba(61, 158, 255, 0.16), transparent 36%);
         pointer-events: none;
     }
-
-    .intel-hero-content {
-        position: relative;
-        z-index: 1;
-    }
+    .intel-hero-content { position: relative; z-index: 1; }
 
     .hero-kicker {
         display: inline-flex;
         align-items: center;
         gap: 0.45rem;
-        font-size: 0.82rem;
-        letter-spacing: 0.08em;
+        font-family: var(--font-mono);
+        font-size: 0.74rem;
+        letter-spacing: 0.18em;
         text-transform: uppercase;
-        font-weight: 700;
-        color: #d1fae5;
-        background: rgba(3, 7, 18, 0.28);
-        border: 1px solid rgba(255, 255, 255, 0.2);
-        padding: 0.45rem 0.8rem;
+        font-weight: 600;
+        color: var(--accent);
+        background: var(--highlight);
+        border: 1px solid rgba(0, 255, 136, 0.3);
+        padding: 0.4rem 0.85rem;
         border-radius: 999px;
-        margin-bottom: 1rem;
+        margin-bottom: 1.25rem;
+    }
+    .hero-kicker::before {
+        content: '';
+        width: 7px; height: 7px; border-radius: 50%;
+        background: var(--accent);
+        box-shadow: 0 0 8px var(--accent);
+        animation: blink 1.6s ease-in-out infinite;
     }
 
     .hero-title {
-        font-size: clamp(2rem, 4vw, 3rem);
-        margin-bottom: 0.85rem;
-        line-height: 1.15;
+        font-family: var(--font-display);
+        font-weight: 400;
+        font-size: clamp(2.4rem, 5vw, 3.8rem);
+        letter-spacing: 2px;
+        line-height: 1.04;
+        margin-bottom: 0.95rem;
         border-bottom: none;
-        color: #f8fafc;
+        background: linear-gradient(135deg, var(--accent) 0%, var(--accent-dim) 45%, var(--accent3) 100%);
+        -webkit-background-clip: text;
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
     }
+    .hero-title::after { display: none; }
 
     .hero-subtitle {
-        color: rgba(248, 250, 252, 0.92);
+        color: var(--text-soft);
         max-width: 900px;
-        font-size: 1.12rem;
-        margin-bottom: 1.6rem;
+        font-size: 1.08rem;
+        margin-bottom: 1.5rem;
     }
 
     .trend-chip {
         display: inline-flex;
         align-items: center;
-        gap: 0.45rem;
+        gap: 0.5rem;
+        font-family: var(--font-mono);
         border-radius: 999px;
-        font-size: 0.9rem;
-        font-weight: 600;
-        padding: 0.45rem 0.9rem;
+        font-size: 0.82rem;
+        font-weight: 500;
+        padding: 0.4rem 0.9rem;
         margin-bottom: 2rem;
-        border: 1px solid transparent;
+        border: 1px solid var(--border);
+        background: var(--surface-3);
+        color: var(--text-soft);
     }
-
-    .trend-chip.up {
-        background: rgba(254, 242, 242, 0.16);
-        color: #fee2e2;
-        border-color: rgba(248, 113, 113, 0.45);
-    }
-
-    .trend-chip.down {
-        background: rgba(236, 253, 245, 0.16);
-        color: #d1fae5;
-        border-color: rgba(16, 185, 129, 0.45);
-    }
-
-    .trend-chip.steady {
-        background: rgba(236, 253, 245, 0.14);
-        color: #ccfbf1;
-        border-color: rgba(45, 212, 191, 0.45);
-    }
+    .trend-chip.up { color: #ffb3c4; border-color: rgba(255, 51, 102, 0.45); background: rgba(255, 51, 102, 0.08); }
+    .trend-chip.down { color: var(--accent); border-color: rgba(0, 255, 136, 0.45); background: var(--highlight); }
+    .trend-chip.steady { color: var(--accent3); border-color: rgba(61, 158, 255, 0.45); background: rgba(61, 158, 255, 0.08); }
 
     .stats-showcase {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+        gap: 0.85rem;
         margin-bottom: 2rem;
     }
-
     .stat-box {
-        background: rgba(8, 47, 73, 0.45);
-        border: 1px solid rgba(186, 230, 253, 0.3);
-        border-radius: 14px;
+        background: rgba(5, 5, 10, 0.55);
+        border: 1px solid var(--border);
+        border-left: 2px solid rgba(0, 255, 136, 0.45);
+        border-radius: var(--border-radius);
         padding: 1rem 1.1rem;
-        backdrop-filter: blur(7px);
     }
-
     .stat-label {
         display: block;
-        font-size: 0.75rem;
+        font-family: var(--font-mono);
+        font-size: 0.68rem;
         text-transform: uppercase;
-        letter-spacing: 0.07em;
-        color: #bfdbfe;
-        margin-bottom: 0.35rem;
+        letter-spacing: 0.12em;
+        color: var(--muted);
+        margin-bottom: 0.4rem;
     }
-
     .stat-number {
         display: block;
-        font-size: clamp(1.35rem, 2.8vw, 1.95rem);
-        color: #f8fafc;
-        font-weight: 700;
-        line-height: 1.2;
+        font-family: var(--font-display);
+        font-size: clamp(1.7rem, 3vw, 2.3rem);
+        letter-spacing: 1px;
+        color: var(--accent);
+        line-height: 1.1;
     }
 
-    .hero-cta {
-        display: flex;
-        gap: 0.75rem;
-        flex-wrap: wrap;
-    }
-
+    .hero-cta { display: flex; gap: 0.7rem; flex-wrap: wrap; }
     .cta-btn {
         display: inline-flex;
         align-items: center;
         gap: 0.45rem;
+        font-family: var(--font-mono);
+        font-size: 0.84rem;
+        letter-spacing: 0.5px;
         font-weight: 600;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         text-decoration: none;
-        padding: 0.8rem 1.1rem;
-        transition: transform 0.2s ease, box-shadow 0.2s ease;
+        padding: 0.75rem 1.15rem;
+        border: 1px solid var(--border);
+        transition: transform 0.18s ease, border-color 0.18s ease, color 0.18s ease, background 0.18s ease;
     }
-
-    .cta-btn:hover {
-        transform: translateY(-2px);
-    }
-
+    .cta-btn:hover { transform: translateY(-2px); }
     .cta-btn.primary {
-        background: #f8fafc;
-        color: #0f172a;
-        box-shadow: 0 10px 18px rgba(8, 47, 73, 0.2);
+        background: var(--accent);
+        color: #05140d;
+        border-color: var(--accent);
+        box-shadow: 0 0 22px rgba(0, 255, 136, 0.25);
     }
+    .cta-btn.primary:hover { background: var(--accent-dim); color: #05140d; }
+    .cta-btn.secondary { background: var(--surface-2); color: var(--text-soft); }
+    .cta-btn.secondary:hover { color: var(--accent3); border-color: var(--accent3); background: rgba(61, 158, 255, 0.08); }
 
-    .cta-btn.secondary {
-        background: rgba(8, 47, 73, 0.35);
-        color: #e2f2ff;
-        border: 1px solid rgba(186, 230, 253, 0.4);
-    }
-
+    /* ---- Insight grid --------------------------------------------- */
     .insight-grid {
         display: grid;
         grid-template-columns: 1.05fr 0.95fr;
         gap: 1.5rem;
         margin-bottom: 2.5rem;
     }
-
     .intel-panel {
-        background: #ffffff;
-        border: 1px solid #dbeafe;
-        border-radius: 16px;
-        box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
-        padding: 1.3rem;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
+        padding: 1.4rem;
     }
-
     .panel-title {
         margin: 0;
-        font-size: 1.3rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        font-size: 1.5rem;
+        letter-spacing: 1px;
+        color: var(--accent);
+        border-bottom: none;
     }
+    .panel-subtitle { margin: 0.35rem 0 1.1rem 0; color: var(--muted); font-size: 0.9rem; }
 
-    .panel-subtitle {
-        margin: 0.35rem 0 1rem 0;
-        color: #64748b;
-        font-size: 0.95rem;
-    }
-
-    .correlation-list {
-        display: grid;
-        gap: 0.8rem;
-    }
-
+    .correlation-list { display: grid; gap: 0.7rem; }
     .correlation-item {
-        border: 1px solid #e2e8f0;
-        border-radius: 12px;
-        background: #f8fafc;
-        padding: 0.9rem 0.95rem;
+        border: 1px solid var(--border);
+        border-left: 2px solid rgba(255, 51, 102, 0.5);
+        border-radius: var(--border-radius);
+        background: var(--surface-2);
+        padding: 0.85rem 0.95rem;
     }
+    .correlation-head { display: flex; justify-content: space-between; align-items: baseline; gap: 0.75rem; margin-bottom: 0.3rem; }
+    .correlation-title { margin: 0; font-size: 0.95rem; color: var(--text); }
+    .correlation-metric { margin: 0; font-family: var(--font-mono); color: var(--accent2); font-weight: 700; font-size: 0.9rem; }
+    .correlation-detail { margin: 0; font-size: 0.84rem; color: var(--muted); }
 
-    .correlation-head {
-        display: flex;
-        justify-content: space-between;
-        align-items: baseline;
-        gap: 0.75rem;
-        margin-bottom: 0.3rem;
-    }
+    .signal-list { display: grid; gap: 0.7rem; }
+    .signal-row { border: 1px solid var(--border); border-radius: var(--border-radius); padding: 0.7rem 0.8rem; background: var(--surface-2); }
+    .signal-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 0.5rem; gap: 0.6rem; }
+    .signal-name { margin: 0; font-size: 0.88rem; color: var(--text); }
+    .signal-metric { margin: 0; font-family: var(--font-mono); font-size: 0.78rem; color: var(--accent3); font-weight: 500; }
+    .signal-bar { height: 6px; background: var(--surface-3); border-radius: 999px; overflow: hidden; }
+    .signal-bar-fill { height: 100%; background: linear-gradient(90deg, var(--accent-dim), var(--accent)); border-radius: 999px; box-shadow: 0 0 8px rgba(0,255,136,0.4); }
 
-    .correlation-title {
-        margin: 0;
-        font-size: 0.98rem;
-        color: #0f172a;
-    }
-
-    .correlation-metric {
-        margin: 0;
-        color: #0f766e;
-        font-weight: 700;
-        font-size: 0.94rem;
-    }
-
-    .correlation-detail {
-        margin: 0;
-        font-size: 0.86rem;
-        color: #475569;
-    }
-
-    .signal-list {
-        display: grid;
-        gap: 0.78rem;
-    }
-
-    .signal-row {
-        border: 1px solid #e2e8f0;
-        border-radius: 11px;
-        padding: 0.72rem 0.78rem;
-        background: #ffffff;
-    }
-
-    .signal-head {
-        display: flex;
-        justify-content: space-between;
-        align-items: baseline;
-        margin-bottom: 0.45rem;
-        gap: 0.6rem;
-    }
-
-    .signal-name {
-        margin: 0;
-        font-size: 0.9rem;
-        color: #0f172a;
-    }
-
-    .signal-metric {
-        margin: 0;
-        font-size: 0.82rem;
-        color: #0369a1;
-        font-weight: 600;
-    }
-
-    .signal-bar {
-        height: 7px;
-        background: #e2e8f0;
-        border-radius: 999px;
-        overflow: hidden;
-    }
-
-    .signal-bar-fill {
-        height: 100%;
-        background: linear-gradient(90deg, #0e7490, #0891b2);
-        border-radius: 999px;
-    }
-
-    .recent-activity {
-        margin-bottom: 2.8rem;
-    }
-
-    .section-header {
-        margin-bottom: 1.1rem;
-    }
-
+    /* ---- Recent activity ------------------------------------------ */
+    .recent-activity { margin-bottom: 2.8rem; }
+    .section-header { margin-bottom: 1.2rem; }
     .section-title {
         margin: 0;
-        font-size: clamp(1.4rem, 2.6vw, 1.95rem);
+        font-family: var(--font-display);
+        font-weight: 400;
+        font-size: clamp(1.6rem, 2.8vw, 2.2rem);
+        letter-spacing: 1.5px;
+        color: var(--text);
         border-bottom: none;
     }
+    .section-subtitle { margin-top: 0.35rem; color: var(--muted); font-size: 0.9rem; }
 
-    .section-subtitle {
-        margin-top: 0.35rem;
-        color: #64748b;
-        font-size: 0.95rem;
-    }
-
-    .timeline-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 0.9rem;
-        margin-bottom: 1.4rem;
-    }
-
+    .timeline-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 0.85rem; margin-bottom: 1.4rem; }
     .timeline-card {
-        background: #ffffff;
-        border: 1px solid #dbeafe;
-        border-radius: 12px;
-        padding: 0.9rem;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        padding: 0.95rem;
+        transition: border-color 0.18s ease;
     }
+    .timeline-card:hover { border-color: var(--accent); }
+    .timeline-date { font-family: var(--font-mono); font-size: 0.78rem; color: var(--accent); font-weight: 600; margin-bottom: 0.5rem; }
+    .timeline-metrics { display: flex; justify-content: space-between; gap: 0.6rem; margin-bottom: 0.5rem; }
+    .timeline-metrics span { font-family: var(--font-mono); font-size: 0.8rem; color: var(--text-soft); }
+    .timeline-rate-bar { height: 6px; border-radius: 999px; background: var(--surface-3); overflow: hidden; }
+    .timeline-rate-fill { height: 100%; border-radius: 999px; background: linear-gradient(90deg, var(--accent3), var(--accent)); }
 
-    .timeline-date {
-        font-size: 0.8rem;
-        color: #0f766e;
-        font-weight: 700;
-        margin-bottom: 0.45rem;
-    }
-
-    .timeline-metrics {
-        display: flex;
-        justify-content: space-between;
-        gap: 0.6rem;
-        margin-bottom: 0.5rem;
-    }
-
-    .timeline-metrics span {
-        font-size: 0.82rem;
-        color: #334155;
-    }
-
-    .timeline-rate-bar {
-        height: 7px;
-        border-radius: 999px;
-        background: #e2e8f0;
-        overflow: hidden;
-    }
-
-    .timeline-rate-fill {
-        height: 100%;
-        border-radius: 999px;
-        background: linear-gradient(90deg, #0284c7, #0ea5a4);
-    }
-
-    .activity-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-        gap: 0.95rem;
-    }
-
+    .activity-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 0.9rem; }
     .activity-card {
-        background: #ffffff;
-        border: 1px solid #dbeafe;
-        border-radius: 12px;
-        padding: 1rem;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        padding: 1.1rem;
+        transition: transform 0.2s ease, border-color 0.2s ease;
     }
+    .activity-card:hover { transform: translateY(-3px); border-color: var(--accent); }
+    .activity-date { font-family: var(--font-mono); color: var(--accent3); font-size: 0.8rem; font-weight: 600; margin-bottom: 0.4rem; }
+    .activity-title { font-size: 1rem; margin: 0 0 0.8rem 0; color: var(--text); }
+    .activity-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.45rem; margin-bottom: 0.8rem; }
+    .activity-stats .mini-stat { min-width: 0; width: 100%; flex: initial; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius); padding: 0.5rem; text-align: center; }
+    .activity-stats .mini-stat-value { display: block; font-family: var(--font-display); font-size: 1.3rem; color: var(--accent); }
+    .activity-stats .mini-stat-label { display: block; font-family: var(--font-mono); font-size: 0.62rem; color: var(--muted); text-transform: uppercase; letter-spacing: 1px; }
+    .view-report-btn { display: inline-flex; align-items: center; gap: 0.35rem; font-family: var(--font-mono); font-size: 0.82rem; font-weight: 600; color: var(--accent); }
+    .activity-actions { text-align: center; margin-top: 1.3rem; }
 
-    .activity-date {
-        color: #0369a1;
-        font-size: 0.82rem;
-        font-weight: 700;
-        margin-bottom: 0.4rem;
-    }
-
-    .activity-title {
-        font-size: 1.02rem;
-        margin: 0 0 0.7rem 0;
-    }
-
-    .activity-stats {
-        display: grid;
-        grid-template-columns: repeat(3, 1fr);
-        gap: 0.45rem;
-        margin-bottom: 0.75rem;
-    }
-
-    .activity-stats .mini-stat {
-        min-width: 0;
-        width: 100%;
-        flex: initial;
-        background: #f8fafc;
-        border-radius: 8px;
-        padding: 0.45rem;
-        text-align: center;
-    }
-
-    .activity-stats .mini-stat-value {
-        display: block;
-        font-size: 1.02rem;
-        color: #0f172a;
-        font-weight: 700;
-    }
-
-    .activity-stats .mini-stat-label {
-        display: block;
-        font-size: 0.7rem;
-        color: #64748b;
-        text-transform: uppercase;
-    }
-
-    .view-report-btn {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.35rem;
-        font-weight: 600;
-        color: #0e7490;
-    }
-
-    .activity-actions {
-        text-align: center;
-        margin-top: 1.1rem;
-    }
-
+    /* ---- Features ------------------------------------------------- */
     .features-section {
-        background: linear-gradient(160deg, #ecfeff 0%, #f8fafc 42%, #ecfeff 100%);
-        border: 1px solid #dbeafe;
-        border-radius: 16px;
-        padding: 1.45rem;
+        background: linear-gradient(160deg, var(--surface) 0%, var(--surface-2) 100%);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        padding: 1.6rem;
         margin-bottom: 2.4rem;
     }
-
-    .features-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 0.8rem;
-        margin-top: 0.95rem;
-    }
-
+    .features-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 0.85rem; margin-top: 1rem; }
     .feature-card {
-        border-radius: 11px;
-        background: #ffffff;
-        border: 1px solid #e2e8f0;
-        padding: 0.9rem;
+        border-radius: var(--border-radius);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-top: 2px solid rgba(0, 255, 136, 0.4);
+        padding: 1.05rem;
+        transition: border-color 0.18s ease, transform 0.18s ease;
     }
+    .feature-card:hover { border-color: var(--accent); transform: translateY(-2px); }
+    .feature-title { margin: 0 0 0.4rem 0; font-family: var(--font-mono); font-size: 0.9rem; letter-spacing: 0.5px; color: var(--accent); border-bottom: none; }
+    .feature-description { margin: 0; font-size: 0.86rem; color: var(--muted); }
 
-    .feature-title {
-        margin: 0 0 0.35rem 0;
-        font-size: 1rem;
-        border-bottom: none;
-    }
-
-    .feature-description {
-        margin: 0;
-        font-size: 0.88rem;
-        color: #475569;
-    }
-
+    /* ---- CTA ------------------------------------------------------ */
     .cta-section {
-        background: #0f172a;
-        border-radius: 16px;
-        padding: 1.5rem;
-        color: #e2e8f0;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        border-radius: var(--border-radius);
+        padding: 1.75rem;
+        color: var(--text-soft);
         margin-bottom: 0.5rem;
     }
-
     .cta-section h2 {
-        color: #f8fafc;
+        color: var(--text);
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
         margin: 0 0 0.65rem 0;
         border-bottom: none;
     }
+    .cta-section p { color: var(--muted); margin-bottom: 1.2rem; }
 
-    .cta-section p {
-        color: #cbd5e1;
-        margin-bottom: 1rem;
-    }
-
-    @media (max-width: 980px) {
-        .insight-grid {
-            grid-template-columns: 1fr;
-        }
-    }
-
+    @media (max-width: 980px) { .insight-grid { grid-template-columns: 1fr; } }
     @media (max-width: 768px) {
-        .intel-hero {
-            padding: 2.3rem 1.2rem;
-        }
-
-        .activity-stats {
-            grid-template-columns: 1fr;
-        }
+        .intel-hero { padding: 2.3rem 1.2rem; }
+        .activity-stats { grid-template-columns: 1fr; }
     }
 </style>
 {% endblock %}
@@ -484,7 +313,7 @@
 <section class="intel-hero">
     <div class="intel-hero-content">
         <div class="hero-kicker">Live Threat Surface</div>
-        <h1 class="hero-title">ClickGrab Threat Intelligence, rebuilt for speed and clarity</h1>
+        <h1 class="hero-title">ClickGrab Threat Intelligence</h1>
         <p class="hero-subtitle">
             Daily telemetry from ClickFix and FakeCAPTCHA campaigns, correlated into one view so teams can spot the chain:
             social lure, clipboard abuse, and execution behavior.

--- a/templates/mitigations.html
+++ b/templates/mitigations.html
@@ -6,218 +6,260 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .mitigations-header {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .mitigations-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .mitigations-subtitle {
         font-size: 1.2rem;
-        color: rgba(255, 255, 255, 0.9);
+        color: var(--text-soft);
         max-width: 600px;
         margin: 0 auto;
         line-height: 1.6;
     }
-    
+
     .mitigation-section {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
         margin-bottom: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
     }
-    
+
     .mitigation-section h2 {
-        color: #333;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin-bottom: 1.5rem;
         font-size: 1.8rem;
         display: flex;
         align-items: center;
         gap: 0.5rem;
     }
-    
+
+    .mitigation-section h2 i {
+        color: var(--accent);
+    }
+
     .mitigation-section h3 {
-        color: #555;
+        color: var(--text-soft);
         margin-bottom: 1rem;
         font-size: 1.3rem;
         margin-top: 2rem;
     }
-    
+
     .mitigation-section h3:first-child {
         margin-top: 0;
     }
-    
+
+    .mitigation-section p,
+    .mitigation-section li {
+        color: var(--text-soft);
+    }
+
+    .mitigation-section a {
+        color: var(--accent3);
+        text-decoration: none;
+    }
+
+    .mitigation-section a:hover {
+        color: var(--accent);
+        text-decoration: underline;
+    }
+
     .code-block {
-        background: #f8f9fa;
-        border: 1px solid #e9ecef;
-        border-radius: 8px;
+        background: #05050a;
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
+        border-radius: var(--border-radius);
         padding: 1.5rem;
         margin: 1rem 0;
-        font-family: 'Courier New', monospace;
+        font-family: var(--font-mono);
         font-size: 0.9rem;
         line-height: 1.5;
+        color: var(--accent3);
         overflow-x: auto;
     }
-    
+
     .warning-box {
-        background: #fff3cd;
-        border: 1px solid #ffeaa7;
-        border-radius: 8px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 1rem;
         margin: 1rem 0;
-        border-left: 4px solid #f39c12;
+        border-left: 3px solid var(--accent4);
+        color: var(--text-soft);
     }
-    
+
     .info-box {
-        background: #d1ecf1;
-        border: 1px solid #bee5eb;
-        border-radius: 8px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 1rem;
         margin: 1rem 0;
-        border-left: 4px solid #17a2b8;
+        border-left: 3px solid var(--accent3);
+        color: var(--text-soft);
     }
-    
+
     .tool-card {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface-2);
+        border-radius: var(--border-radius);
         padding: 1.5rem;
         margin: 1rem 0;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-        border: 1px solid #e1e5e9;
-        transition: transform 0.2s ease, box-shadow 0.2s ease;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        transition: transform 0.18s ease, border-color 0.18s ease;
     }
-    
+
     .tool-card:hover {
         transform: translateY(-2px);
-        box-shadow: 0 4px 20px rgba(0,0,0,0.15);
+        border-color: var(--accent);
     }
-    
+
     .tool-header {
         display: flex;
         align-items: center;
         gap: 1rem;
         margin-bottom: 1rem;
     }
-    
+
     .tool-icon {
         width: 48px;
         height: 48px;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        border-radius: 12px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         display: flex;
         align-items: center;
         justify-content: center;
-        color: white;
+        color: var(--accent);
         font-size: 1.5rem;
     }
-    
+
     .tool-title {
+        font-family: var(--font-display);
         font-size: 1.3rem;
-        font-weight: 600;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .tool-description {
-        color: #666;
+        color: var(--text-soft);
         line-height: 1.6;
         margin-bottom: 1rem;
     }
-    
+
     .tool-links {
         display: flex;
         gap: 1rem;
         flex-wrap: wrap;
     }
-    
+
     .tool-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: #f8f9fa;
-        border: 1px solid #e9ecef;
-        border-radius: 6px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         text-decoration: none;
-        color: #495057;
+        color: var(--text-soft);
+        font-family: var(--font-mono);
         font-size: 0.9rem;
-        transition: all 0.2s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .tool-link:hover {
-        background: #e9ecef;
-        color: #333;
+        background: var(--surface-3);
+        border-color: var(--accent);
+        color: var(--accent);
         text-decoration: none;
     }
-    
+
     .tool-link.github {
-        background: #24292e;
-        color: white;
-        border-color: #24292e;
+        background: var(--surface-3);
+        color: var(--text);
+        border-color: var(--border);
     }
-    
+
     .tool-link.github:hover {
-        background: #1a1e22;
-        color: white;
+        border-color: var(--accent);
+        color: var(--accent);
     }
-    
+
     .contributor-info {
-        background: #f8f9fa;
-        border-radius: 8px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 1rem;
         margin: 1rem 0;
-        border-left: 4px solid #28a745;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .contributor-name {
+        font-family: var(--font-mono);
         font-weight: 600;
-        color: #28a745;
+        letter-spacing: 0.5px;
+        color: var(--accent);
         margin-bottom: 0.5rem;
     }
-    
+
     .contributor-links {
         display: flex;
         gap: 1rem;
         flex-wrap: wrap;
     }
-    
+
     .contributor-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
+        font-family: var(--font-mono);
         font-size: 0.9rem;
     }
-    
+
     .contributor-link:hover {
+        color: var(--accent);
         text-decoration: underline;
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
+        font-family: var(--font-mono);
         font-weight: 500;
+        letter-spacing: 0.5px;
         margin-bottom: 2rem;
-        transition: color 0.2s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .back-link:hover {
-        color: #5a6fd8;
+        color: var(--accent);
         text-decoration: none;
     }
     

--- a/templates/report.html
+++ b/templates/report.html
@@ -6,15 +6,18 @@
 <style>
     /* Report Header */
     .report-hero {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         position: relative;
         overflow: hidden;
+        box-shadow: var(--shadow);
     }
-    
+
     .report-hero::before {
         content: '';
         position: absolute;
@@ -22,27 +25,31 @@
         left: 0;
         right: 0;
         bottom: 0;
-        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><pattern id="grid" width="10" height="10" patternUnits="userSpaceOnUse"><path d="M 10 0 L 0 0 0 10" fill="none" stroke="rgba(255,255,255,0.1)" stroke-width="0.5"/></pattern><rect width="100" height="100" fill="url(%23grid)"/></svg>');
-        opacity: 0.3;
+        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><pattern id="grid" width="10" height="10" patternUnits="userSpaceOnUse"><path d="M 10 0 L 0 0 0 10" fill="none" stroke="rgba(0,255,136,0.06)" stroke-width="0.5"/></pattern><rect width="100" height="100" fill="url(%23grid)"/></svg>');
+        opacity: 0.5;
     }
-    
+
     .report-hero-content {
         position: relative;
         z-index: 1;
     }
-    
+
     .report-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 700;
+        font-weight: 400;
+        letter-spacing: 2px;
+        color: var(--accent);
         margin-bottom: 1rem;
     }
-    
+
     .report-meta {
         display: flex;
         gap: 2rem;
         flex-wrap: wrap;
-        font-size: 1.1rem;
-        opacity: 0.95;
+        font-family: var(--font-mono);
+        font-size: 0.95rem;
+        color: var(--text-soft);
     }
     
     /* Summary Cards */
@@ -54,78 +61,82 @@
     }
     
     .summary-card {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 1.5rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+        box-shadow: var(--shadow);
         text-align: center;
-        transition: transform 0.3s ease;
-        border: 1px solid #e5e7eb;
+        transition: transform 0.18s ease, border-color 0.18s ease;
+        border: 1px solid var(--border);
         position: relative;
         overflow: hidden;
     }
-    
+
     .summary-card::before {
         content: '';
         position: absolute;
         top: 0;
         left: 0;
         right: 0;
-        height: 4px;
-        background: linear-gradient(90deg, var(--gradient-start), var(--gradient-end));
+        height: 3px;
+        background: var(--accent-edge, var(--accent));
     }
-    
-    .summary-card.total { --gradient-start: #0e7490; --gradient-end: #0f766e; }
-    .summary-card.threats { --gradient-start: #22c55e; --gradient-end: #0891b2; }
-    .summary-card.powershell { --gradient-start: #4facfe; --gradient-end: #00f2fe; }
-    .summary-card.clipboard { --gradient-start: #fa709a; --gradient-end: #fee140; }
-    .summary-card.score { --gradient-start: #30cfd0; --gradient-end: #330867; }
-    
+
+    .summary-card.total { --accent-edge: var(--accent3); }
+    .summary-card.threats { --accent-edge: var(--accent2); }
+    .summary-card.powershell { --accent-edge: var(--accent3); }
+    .summary-card.clipboard { --accent-edge: var(--accent4); }
+    .summary-card.score { --accent-edge: var(--accent); }
+
     .summary-card:hover {
-        transform: translateY(-5px);
-        box-shadow: 0 8px 30px rgba(0,0,0,0.12);
+        transform: translateY(-2px);
+        border-color: var(--accent);
     }
-    
+
     .summary-icon {
         font-size: 2.5rem;
         margin-bottom: 1rem;
     }
-    
+
     .summary-value {
+        font-family: var(--font-mono);
         font-size: 2.5rem;
         font-weight: 700;
-        color: var(--text-color);
+        color: var(--text);
         margin-bottom: 0.5rem;
     }
-    
+
     .summary-label {
-        color: var(--text-light);
+        font-family: var(--font-mono);
+        color: var(--muted);
         font-size: 0.9rem;
         text-transform: uppercase;
         letter-spacing: 0.5px;
     }
-    
+
     .summary-change {
         margin-top: 0.5rem;
+        font-family: var(--font-mono);
         font-size: 0.85rem;
         display: flex;
         align-items: center;
         justify-content: center;
         gap: 0.25rem;
     }
-    
-    .change-up { color: #ef4444; }
-    .change-down { color: #22c55e; }
+
+    .change-up { color: var(--accent2); }
+    .change-down { color: var(--accent); }
     
     /* Threat Overview */
     .threat-overview {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
         margin-bottom: 3rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+        box-shadow: var(--shadow);
     }
-    
+
     .threat-header {
         display: flex;
         justify-content: space-between;
@@ -134,33 +145,36 @@
         flex-wrap: wrap;
         gap: 1rem;
     }
-    
+
     .threat-title {
+        font-family: var(--font-display);
         font-size: 1.75rem;
-        font-weight: 600;
-        color: var(--text-color);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
     }
-    
+
     .threat-actions {
         display: flex;
         gap: 1rem;
     }
-    
+
     .action-btn {
         padding: 0.5rem 1rem;
-        border: 1px solid #e5e7eb;
-        border-radius: 8px;
-        background: white;
-        color: var(--text-color);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        background: var(--surface-2);
+        color: var(--text-soft);
+        font-family: var(--font-mono);
         font-size: 0.9rem;
         cursor: pointer;
-        transition: all 0.2s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .action-btn:hover {
-        background: #f9fafb;
-        border-color: #0e7490;
-        color: #0e7490;
+        background: var(--surface-3);
+        border-color: var(--accent);
+        color: var(--accent);
     }
 
     /* Simple bar chart styles */
@@ -171,14 +185,14 @@
         margin-top: 1rem;
     }
     .bar {
-        background: #f9fafb;
-        border: 1px solid #e5e7eb;
-        border-radius: 8px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 0.75rem;
     }
-    .bar-label { font-size: 0.9rem; color: var(--text-light); }
-    .bar-track { height: 10px; background: #eef2ff; border-radius: 6px; margin-top: 0.5rem; overflow: hidden; }
-    .bar-fill { height: 100%; background: linear-gradient(90deg,#0e7490,#0f766e); border-radius: 6px; width: 0%; transition: width .6s ease; }
+    .bar-label { font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted); }
+    .bar-track { height: 10px; background: var(--surface-3); border-radius: 6px; margin-top: 0.5rem; overflow: hidden; }
+    .bar-fill { height: 100%; background: var(--accent); border-radius: 6px; width: 0%; transition: width .6s ease; }
     
     /* Site Analysis Cards */
     .sites-section {
@@ -193,27 +207,27 @@
     }
     
     .site-card {
-        background: white;
-        border-radius: 12px;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.08);
+        background: var(--surface);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
         margin-bottom: 1.5rem;
         overflow: hidden;
-        transition: all 0.3s ease;
-        border: 1px solid #e5e7eb;
+        transition: all 0.18s ease;
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
     }
-    
+
     .site-card:hover {
-        box-shadow: 0 4px 20px rgba(0,0,0,0.12);
-        border-color: #0e7490;
+        border-color: var(--accent);
     }
-    
+
     .site-header {
-        background: #f9fafb;
+        background: var(--surface-2);
         padding: 1.5rem;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--border);
         cursor: pointer;
     }
-    
+
     .site-header-content {
         display: flex;
         justify-content: space-between;
@@ -221,41 +235,44 @@
         flex-wrap: wrap;
         gap: 1rem;
     }
-    
+
     .site-url {
         font-weight: 600;
-        color: #ef4444;
+        color: var(--accent2);
         word-break: break-all;
-        font-family: monospace;
+        font-family: var(--font-mono);
         font-size: 0.95rem;
     }
-    
+
     .site-badges {
         display: flex;
         gap: 0.5rem;
         flex-wrap: wrap;
     }
-    
+
     .threat-score-badge {
         padding: 0.25rem 0.75rem;
         border-radius: 20px;
+        font-family: var(--font-mono);
         font-size: 0.8rem;
         font-weight: 600;
-        color: white;
+        color: var(--bg);
     }
-    
-    .score-critical { background: #dc2626; }
-    .score-high { background: #ef4444; }
-    .score-medium { background: #f59e0b; }
-    .score-low { background: #3b82f6; }
-    
+
+    .score-critical { background: var(--accent2); }
+    .score-high { background: var(--accent2); }
+    .score-medium { background: var(--accent4); }
+    .score-low { background: var(--accent); }
+
     .attack-type-badge {
         padding: 0.25rem 0.75rem;
         border-radius: 20px;
+        font-family: var(--font-mono);
         font-size: 0.8rem;
         font-weight: 500;
-        background: #e0e7ff;
-        color: #4c1d95;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent3);
     }
     
     .site-details {
@@ -271,28 +288,29 @@
         display: flex;
         gap: 1rem;
         margin-bottom: 1.5rem;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--border);
     }
-    
+
     .detail-tab {
         padding: 0.5rem 1rem;
         border: none;
         background: none;
-        color: var(--text-light);
+        color: var(--muted);
+        font-family: var(--font-mono);
         font-weight: 500;
         cursor: pointer;
         position: relative;
-        transition: color 0.2s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .detail-tab:hover {
-        color: var(--text-color);
+        color: var(--text);
     }
-    
+
     .detail-tab.active {
-        color: #0e7490;
+        color: var(--accent);
     }
-    
+
     .detail-tab.active::after {
         content: '';
         position: absolute;
@@ -300,7 +318,7 @@
         left: 0;
         right: 0;
         height: 2px;
-        background: #0e7490;
+        background: var(--accent);
     }
     
     .tab-content {
@@ -320,132 +338,152 @@
         font-size: 1.1rem;
         font-weight: 600;
         margin-bottom: 1rem;
-        color: var(--text-color);
+        color: var(--text);
         display: flex;
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .indicator-count {
-        background: #e0e7ff;
-        color: #4c1d95;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent3);
         padding: 0.125rem 0.5rem;
         border-radius: 12px;
+        font-family: var(--font-mono);
         font-size: 0.8rem;
         font-weight: 500;
     }
-    
+
     .indicator-list {
-        background: #f9fafb;
-        border-radius: 8px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 1rem;
-        font-family: monospace;
+        font-family: var(--font-mono);
         font-size: 0.85rem;
         max-height: 300px;
         overflow-y: auto;
     }
-    
+
     .indicator-item {
         padding: 0.5rem;
         margin-bottom: 0.5rem;
-        background: white;
-        border-radius: 4px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        color: var(--text-soft);
         word-break: break-all;
     }
-    
+
     .code-block {
-        background: #1e293b;
-        color: #e2e8f0;
+        background: #05050a;
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
+        color: var(--text-soft);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         overflow-x: auto;
-        font-family: monospace;
+        font-family: var(--font-mono);
         font-size: 0.85rem;
         position: relative;
         margin-bottom: 1rem;
     }
-    
+
     .copy-btn {
         position: absolute;
         top: 0.5rem;
         right: 0.5rem;
-        background: rgba(255,255,255,0.1);
-        border: 1px solid rgba(255,255,255,0.2);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--accent);
         padding: 0.25rem 0.75rem;
-        border-radius: 4px;
+        border-radius: var(--border-radius);
+        font-family: var(--font-mono);
         font-size: 0.75rem;
         cursor: pointer;
-        transition: background 0.2s ease;
+        transition: all 0.18s ease;
     }
-    
+
     .copy-btn:hover {
-        background: rgba(255,255,255,0.2);
+        background: var(--surface);
+        border-color: var(--accent);
     }
-    
+
     /* Analysis Section */
     .analysis-section {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+        box-shadow: var(--shadow);
     }
-    
+
     .analysis-content {
         line-height: 1.8;
-        color: var(--text-color);
+        color: var(--text-soft);
     }
-    
+
     .analysis-content h2 {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        color: #0e7490;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 2rem 0 1rem;
         padding-bottom: 0.5rem;
-        border-bottom: 2px solid #e0e7ff;
+        border-bottom: 1px solid var(--border);
     }
-    
+
     .analysis-content h3 {
         font-size: 1.25rem;
-        color: var(--text-color);
+        color: var(--text);
         margin: 1.5rem 0 1rem;
     }
-    
+
     .analysis-content pre {
-        background: #f9fafb;
-        border: 1px solid #e5e7eb;
-        border-radius: 8px;
+        background: #05050a;
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
+        border-radius: var(--border-radius);
         padding: 1rem;
         overflow-x: auto;
         margin: 1rem 0;
+        font-family: var(--font-mono);
+        color: var(--text-soft);
     }
-    
+
     .analysis-content code {
-        background: #f3f4f6;
+        background: var(--surface-3);
+        color: var(--accent3);
         padding: 0.125rem 0.25rem;
         border-radius: 3px;
+        font-family: var(--font-mono);
         font-size: 0.9em;
     }
-    
+
     .analysis-content table {
         width: 100%;
         border-collapse: collapse;
         margin: 1rem 0;
     }
-    
+
     .analysis-content th,
     .analysis-content td {
         padding: 0.75rem;
         text-align: left;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--border);
     }
-    
+
     .analysis-content th {
-        background: #f9fafb;
+        background: var(--surface-2);
+        color: var(--accent);
         font-weight: 600;
+        border-bottom: 2px solid var(--accent);
     }
-    
+
     .analysis-content tr:hover {
-        background: #f9fafb;
+        background: var(--highlight);
     }
     
     /* Responsive */
@@ -473,7 +511,7 @@
     .empty-state {
         text-align: center;
         padding: 3rem;
-        color: var(--text-light);
+        color: var(--muted);
     }
     
     .empty-icon {
@@ -500,7 +538,7 @@
 <!-- Download Section -->
 <div style="display: flex; gap: 1rem; margin-bottom: 2rem; flex-wrap: wrap;">
     <a href="https://github.com/MHaggis/ClickGrab/tree/main/nightly_reports" 
-       class="action-btn" style="text-decoration: none; background: #0e7490; color: white; padding: 0.75rem 1.5rem;" target="_blank">
+       class="action-btn" style="text-decoration: none; background: var(--accent); border-color: var(--accent); color: var(--bg); padding: 0.75rem 1.5rem;" target="_blank">
         ⬇️ Download JSON Report
     </a>
     <a href="https://github.com/MHaggis/ClickGrab/tree/main/nightly_reports" 
@@ -556,29 +594,29 @@
     </div>
     
     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin-bottom: 2rem;">
-        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-            <div style="font-size: 1.5rem; font-weight: 700; color: #dc2626;">{{ summary.high_risk_commands|default(0) }}</div>
-            <div style="font-size: 0.9rem; color: var(--text-light);">High Risk Commands</div>
+        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent2);">{{ summary.high_risk_commands|default(0) }}</div>
+            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">High Risk Commands</div>
         </div>
-        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-            <div style="font-size: 1.5rem; font-weight: 700; color: #f59e0b;">{{ summary.base64_strings|default(0) }}</div>
-            <div style="font-size: 0.9rem; color: var(--text-light);">Base64 Encoded</div>
+        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent4);">{{ summary.base64_strings|default(0) }}</div>
+            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">Base64 Encoded</div>
         </div>
-        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-            <div style="font-size: 1.5rem; font-weight: 700; color: #8b5cf6;">{{ summary.obfuscated_javascript|default(0) }}</div>
-            <div style="font-size: 0.9rem; color: var(--text-light);">Obfuscated JS</div>
+        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent3);">{{ summary.obfuscated_javascript|default(0) }}</div>
+            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">Obfuscated JS</div>
         </div>
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.5rem; font-weight: 700; color: #3b82f6;">{{ summary.javascript_redirects|default(0) }}</div>
-                            <div style="font-size: 0.9rem; color: var(--text-light);">Inline JS Redirects</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent3);">{{ summary.javascript_redirects|default(0) }}</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">Inline JS Redirects</div>
                         </div>
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                        <div style="font-size: 1.5rem; font-weight: 700; color: #ec4899;">{{ summary.javascript_redirect_chains|default(0) }}</div>
-                            <div style="font-size: 0.9rem; color: var(--text-light);">External JS Chains</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                        <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent2);">{{ summary.javascript_redirect_chains|default(0) }}</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">External JS Chains</div>
                         </div>
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.5rem; font-weight: 700; color: #22c55e;">{{ summary.redirect_follows|default(0) }}</div>
-                            <div style="font-size: 0.9rem; color: var(--text-light);">Redirect Follows</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.5rem; font-weight: 700; color: var(--accent);">{{ summary.redirect_follows|default(0) }}</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.9rem; color: var(--muted);">Redirect Follows</div>
                         </div>
     </div>
 
@@ -601,7 +639,7 @@
         <h3 style="margin:0 0 .5rem 0;">Top Indicators/Keywords</h3>
         <div style="display:flex; gap:.5rem; flex-wrap:wrap;">
             {% for item in top_keywords %}
-            <span style="background:#eef2ff;border:1px solid #c7d2fe;color:#1e1b4b;border-radius:999px;padding:.25rem .6rem;font-size:.85rem;">{{ item[0] }} ({{ item[1] }})</span>
+            <span style="background:var(--surface-3);border:1px solid var(--border);color:var(--accent3);border-radius:999px;padding:.25rem .6rem;font-family:var(--font-mono);font-size:.85rem;">{{ item[0] }} ({{ item[1] }})</span>
             {% endfor %}
         </div>
     </div>
@@ -611,8 +649,8 @@
 <!-- Detailed Site Analysis -->
 <section class="sites-section">
     <div class="sites-header">
-        <h2 style="font-size: 1.75rem; font-weight: 600;">Malicious Sites Detected</h2>
-        <span style="color: var(--text-light);">Click on a site to view detailed analysis</span>
+        <h2 style="font-family: var(--font-display); font-size: 1.75rem; font-weight: 400; letter-spacing: 1px; color: var(--text);">Malicious Sites Detected</h2>
+        <span style="font-family: var(--font-mono); color: var(--muted);">Click on a site to view detailed analysis</span>
     </div>
     
     {% if sites %}
@@ -622,7 +660,7 @@
                 <div class="site-header-content">
                     <div>
                         <div class="site-url">{{ site.url }}</div>
-                        <div style="margin-top: 0.5rem; color: var(--text-light); font-size: 0.9rem;">
+                        <div style="margin-top: 0.5rem; font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem;">
                             {{ site.total_indicators }} indicators detected
                         </div>
                     </div>
@@ -655,9 +693,9 @@
                 <div id="overview-{{ loop.index }}" class="tab-content active">
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                         {% for key, value in site.indicators.items() if value > 0 %}
-                        <div style="text-align: center; padding: 1rem; background: #f9fafb; border-radius: 8px;">
-                            <div style="font-size: 1.25rem; font-weight: 600; color: #0e7490;">{{ value }}</div>
-                            <div style="font-size: 0.85rem; color: var(--text-light); text-transform: capitalize;">{{ key|replace('_', ' ') }}</div>
+                        <div style="text-align: center; padding: 1rem; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--border-radius);">
+                            <div style="font-family: var(--font-mono); font-size: 1.25rem; font-weight: 600; color: var(--accent);">{{ value }}</div>
+                            <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--muted); text-transform: capitalize;">{{ key|replace('_', ' ') }}</div>
                         </div>
                         {% endfor %}
                     </div>
@@ -713,7 +751,7 @@
                     {% if site.details.ClipboardManipulation %}
                     <div class="indicator-group">
                         <h4 class="indicator-title">📋 Clipboard Manipulation Code</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first {{ site.details.ClipboardManipulation[:2]|length }} of {{ site.details.ClipboardManipulation|length }} entries (truncated for performance)
                         </p>
                         {% for code in site.details.ClipboardManipulation[:2] %}
@@ -728,7 +766,7 @@
                     {% if site.details.ObfuscatedJavaScript %}
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔐 Obfuscated JavaScript</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first {{ site.details.ObfuscatedJavaScript[:2]|length }} of {{ site.details.ObfuscatedJavaScript|length }} entries (truncated for performance)
                         </p>
                         {% for js in site.details.ObfuscatedJavaScript[:2] %}
@@ -743,7 +781,7 @@
                     {% if site.details.JavaScriptRedirectChains %}
                     <div class="indicator-group">
                         <h4 class="indicator-title">🔁 External JavaScript Redirect Chains</h4>
-                        <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">
+                        <p style="font-family: var(--font-mono); color: var(--muted); font-size: 0.9rem; margin-bottom: 1rem;">
                             Showing first {{ site.details.JavaScriptRedirectChains[:2]|length }} of {{ site.details.JavaScriptRedirectChains|length }} chains (truncated for performance)
                         </p>
                         {% for chain in site.details.JavaScriptRedirectChains[:2] %}
@@ -791,7 +829,7 @@
         {% endfor %}
         
         {% if sites|length > 20 %}
-        <div style="text-align: center; padding: 2rem; color: var(--text-light);">
+        <div style="text-align: center; padding: 2rem; font-family: var(--font-mono); color: var(--muted);">
             <p>Showing top 20 malicious sites. {{ sites|length - 20 }} additional sites detected.</p>
         </div>
         {% endif %}
@@ -807,7 +845,7 @@
 <!-- Technical Analysis Section -->
 {% if analysis_html %}
 <section class="analysis-section">
-    <h2 style="font-size: 1.75rem; font-weight: 600; margin-bottom: 2rem;">Technical Analysis</h2>
+    <h2 style="font-family: var(--font-display); font-size: 1.75rem; font-weight: 400; letter-spacing: 1px; color: var(--text); margin-bottom: 2rem;">Technical Analysis</h2>
     <div class="analysis-content">
         {{ analysis_html|safe }}
     </div>

--- a/templates/reports.html
+++ b/templates/reports.html
@@ -6,16 +6,19 @@
 <style>
     /* Page Header */
     .reports-hero {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 4rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
         position: relative;
         overflow: hidden;
+        box-shadow: var(--shadow);
     }
-    
+
     .reports-hero::after {
         content: '';
         position: absolute;
@@ -23,25 +26,27 @@
         left: 0;
         right: 0;
         height: 100px;
-        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 320"><path fill="rgba(255,255,255,0.1)" d="M0,96L48,112C96,128,192,160,288,165.3C384,171,480,149,576,138.7C672,128,768,128,864,144C960,160,1056,192,1152,186.7C1248,181,1344,139,1392,117.3L1440,96L1440,320L1392,320C1344,320,1248,320,1152,320C1056,320,960,320,864,320C768,320,672,320,576,320C480,320,384,320,288,320C192,320,96,320,48,320L0,320Z"></path></svg>') no-repeat;
+        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 320"><path fill="rgba(0,255,136,0.06)" d="M0,96L48,112C96,128,192,160,288,165.3C384,171,480,149,576,138.7C672,128,768,128,864,144C960,160,1056,192,1152,186.7C1248,181,1344,139,1392,117.3L1440,96L1440,320L1392,320C1344,320,1248,320,1152,320C1056,320,960,320,864,320C768,320,672,320,576,320C480,320,384,320,288,320C192,320,96,320,48,320L0,320Z"></path></svg>') no-repeat;
         background-size: cover;
         pointer-events: none;
     }
-    
+
     .reports-hero h1 {
+        font-family: var(--font-display);
         font-size: 2.5rem;
         margin-bottom: 1rem;
-        font-weight: 700;
+        font-weight: 400;
+        letter-spacing: 2px;
+        color: var(--accent);
     }
-    
+
     .reports-hero p {
         font-size: 1.2rem;
-        color: rgba(255, 255, 255, 0.95);
+        color: var(--text-soft);
         max-width: 600px;
         margin: 0 auto;
-        text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
     }
-    
+
     /* Stats Summary */
     .reports-summary {
         display: grid;
@@ -50,93 +55,108 @@
         max-width: 600px;
         margin: 2rem auto 0;
     }
-    
+
     .summary-stat {
-        background: rgba(255,255,255,0.1);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         text-align: center;
     }
-    
+
     .summary-stat-value {
+        font-family: var(--font-mono);
         font-size: 2rem;
         font-weight: 700;
         display: block;
+        color: var(--accent);
     }
-    
+
     .summary-stat-label {
+        font-family: var(--font-mono);
         font-size: 0.85rem;
-        opacity: 0.9;
+        color: var(--muted);
         text-transform: uppercase;
         letter-spacing: 0.5px;
     }
-    
+
     /* Executive Summary & Key Findings */
     .executive-section {
-        background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
-        border-radius: 16px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 2rem;
         margin-bottom: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border: 1px solid #e2e8f0;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .executive-header {
         display: flex;
         align-items: center;
         gap: 1rem;
         margin-bottom: 1.5rem;
     }
-    
+
     .executive-icon {
         width: 48px;
         height: 48px;
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        border-radius: 12px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         display: flex;
         align-items: center;
         justify-content: center;
         font-size: 24px;
         flex-shrink: 0;
     }
-    
+
     .executive-title {
+        font-family: var(--font-display);
         font-size: 1.75rem;
-        font-weight: 700;
-        color: var(--text-color);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
     }
-    
+
     .executive-content {
-        color: var(--text-light);
+        color: var(--text-soft);
         line-height: 1.8;
         font-size: 1.05rem;
     }
-    
+
     .key-findings {
-        background: white;
-        border-radius: 16px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 2rem;
         margin-bottom: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border: 1px solid #e2e8f0;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
     }
-    
+
     .findings-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
         gap: 1.5rem;
         margin-top: 1.5rem;
     }
-    
+
     .finding-card {
-        background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+        background: var(--surface-2);
         padding: 1.5rem;
-        border-radius: 12px;
-        border: 1px solid #e2e8f0;
+        border-radius: var(--border-radius);
+        border: 1px solid var(--border);
         position: relative;
         overflow: hidden;
+        transition: all 0.18s ease;
     }
-    
+
+    .finding-card:hover {
+        transform: translateY(-2px);
+        border-color: var(--accent);
+    }
+
     .finding-card::before {
         content: '';
         position: absolute;
@@ -144,152 +164,163 @@
         left: 0;
         width: 4px;
         height: 100%;
-        background: linear-gradient(180deg, #0e7490, #0f766e);
+        background: var(--accent);
     }
-    
+
     .finding-icon {
         width: 40px;
         height: 40px;
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        border-radius: 10px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         display: flex;
         align-items: center;
         justify-content: center;
         margin-bottom: 1rem;
         font-size: 20px;
     }
-    
+
     .finding-title {
         font-size: 1.1rem;
         font-weight: 600;
-        color: var(--text-color);
+        color: var(--text);
         margin-bottom: 0.5rem;
     }
-    
+
     .finding-value {
+        font-family: var(--font-mono);
         font-size: 2rem;
         font-weight: 700;
-        color: #0e7490;
+        color: var(--accent);
         margin-bottom: 0.5rem;
     }
-    
+
     .finding-desc {
         font-size: 0.9rem;
-        color: var(--text-light);
+        color: var(--muted);
         line-height: 1.5;
     }
-    
+
     .finding-trend {
         display: inline-flex;
         align-items: center;
         gap: 0.25rem;
+        font-family: var(--font-mono);
         font-size: 0.85rem;
         font-weight: 600;
         margin-top: 0.5rem;
     }
-    
+
     .trend-up {
-        color: #ef4444;
+        color: var(--accent2);
     }
-    
+
     .trend-down {
-        color: #22c55e;
+        color: var(--accent);
     }
-    
+
     /* Table of Contents */
     .toc-section {
-        background: white;
-        border-radius: 16px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 2rem;
         margin-bottom: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border: 1px solid #e2e8f0;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .toc-header {
         display: flex;
         align-items: center;
         gap: 1rem;
         margin-bottom: 1.5rem;
     }
-    
+
     .toc-grid {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
         gap: 1rem;
     }
-    
+
     .toc-item {
-        background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         text-decoration: none;
-        color: var(--text-color);
-        transition: all 0.3s ease;
-        border: 1px solid #e2e8f0;
+        color: var(--text);
+        transition: all 0.18s ease;
+        border: 1px solid var(--border);
         display: flex;
         flex-direction: column;
         gap: 0.25rem;
     }
-    
+
     .toc-item:hover {
-        transform: translateY(-3px);
-        box-shadow: 0 8px 20px rgba(0,0,0,0.12);
-        border-color: #0e7490;
-        color: var(--text-color);
+        transform: translateY(-2px);
+        box-shadow: var(--shadow);
+        border-color: var(--accent);
+        color: var(--text);
     }
-    
+
     .toc-month {
         font-weight: 600;
         font-size: 1.1rem;
+        color: var(--text);
     }
-    
+
     .toc-stats {
+        font-family: var(--font-mono);
         font-size: 0.85rem;
-        color: var(--text-light);
+        color: var(--muted);
     }
-    
+
     .toc-highlight {
+        font-family: var(--font-mono);
         font-size: 0.75rem;
-        color: #0e7490;
+        color: var(--accent);
         font-weight: 500;
     }
-    
+
     /* Month Groups */
     .month-section {
         margin-bottom: 3rem;
         scroll-margin-top: 80px;
     }
-    
+
     .month-header {
         display: flex;
         align-items: center;
         justify-content: space-between;
         margin-bottom: 1.5rem;
         padding-bottom: 0.75rem;
-        border-bottom: 2px solid #e5e7eb;
+        border-bottom: 2px solid var(--accent);
     }
-    
+
     .month-title {
+        font-family: var(--font-display);
         font-size: 1.75rem;
-        font-weight: 600;
-        color: var(--text-color);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
     }
-    
+
     .month-stats {
         display: flex;
         gap: 1.5rem;
+        font-family: var(--font-mono);
         font-size: 0.9rem;
-        color: var(--text-light);
+        color: var(--muted);
     }
-    
+
     /* Back to Top Button */
     .back-to-top {
         position: fixed;
         bottom: 2rem;
         right: 2rem;
-        background: linear-gradient(135deg, #0e7490, #0f766e);
-        color: white;
+        background: var(--surface-2);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         width: 48px;
         height: 48px;
         border-radius: 50%;
@@ -297,246 +328,273 @@
         align-items: center;
         justify-content: center;
         text-decoration: none;
-        box-shadow: 0 4px 20px rgba(102, 126, 234, 0.4);
-        transition: all 0.3s ease;
+        box-shadow: var(--shadow);
+        transition: all 0.18s ease;
         opacity: 0;
         pointer-events: none;
         z-index: 100;
     }
-    
+
     .back-to-top.visible {
         opacity: 1;
         pointer-events: all;
     }
-    
+
     .back-to-top:hover {
-        transform: translateY(-3px);
-        box-shadow: 0 8px 30px rgba(102, 126, 234, 0.5);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--surface-3);
+        box-shadow: var(--shadow);
+        color: var(--accent);
     }
-    
+
     /* Report Cards */
     .reports-grid {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
         gap: 1.5rem;
     }
-    
+
     .report-card {
-        background: white;
-        border-radius: 12px;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.08);
+        background: var(--surface);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
         overflow: hidden;
-        transition: all 0.3s ease;
-        border: 1px solid #e5e7eb;
+        transition: all 0.18s ease;
+        border: 1px solid var(--border);
         position: relative;
     }
-    
+
     .report-card:hover {
-        transform: translateY(-5px);
-        box-shadow: 0 8px 25px rgba(0,0,0,0.12);
-        border-color: #0e7490;
+        transform: translateY(-2px);
+        box-shadow: var(--shadow);
+        border-color: var(--accent);
     }
-    
+
     .report-header {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-2);
+        border-bottom: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 1.25rem;
         position: relative;
     }
-    
+
     .report-date {
+        font-family: var(--font-mono);
         font-size: 0.85rem;
-        opacity: 1;
-        color: #FFFFFF !important;
+        color: var(--muted) !important;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
         margin-bottom: 0.25rem;
     }
-    
+
     .report-title {
         font-size: 1.25rem;
         font-weight: 600;
         margin: 0;
+        color: var(--text);
     }
-    
+
     .threat-badge {
         position: absolute;
         top: 1rem;
         right: 1rem;
         padding: 0.25rem 0.75rem;
-        border-radius: 20px;
+        border-radius: var(--border-radius);
+        font-family: var(--font-mono);
         font-size: 0.75rem;
         font-weight: 600;
-        background: rgba(255,255,255,0.2);
-        backdrop-filter: blur(5px);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        background: var(--surface-3);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
-    
+
     .threat-badge.high {
-        background: rgba(239, 68, 68, 0.9);
+        background: rgba(255, 51, 102, 0.15);
+        border-color: var(--accent2);
+        color: var(--accent2);
     }
-    
+
     .threat-badge.medium {
-        background: rgba(245, 158, 11, 0.9);
+        background: rgba(255, 204, 0, 0.12);
+        border-color: var(--accent4);
+        color: var(--accent4);
     }
-    
+
     .threat-badge.low {
-        background: rgba(34, 197, 94, 0.9);
+        background: rgba(0, 255, 136, 0.12);
+        border-color: var(--accent);
+        color: var(--accent);
     }
-    
+
     .report-body {
         padding: 1.5rem;
     }
-    
+
     .report-metrics {
         display: grid;
         grid-template-columns: repeat(2, 1fr);
         gap: 1rem;
         margin-bottom: 1.5rem;
     }
-    
+
     .metric {
         text-align: center;
         padding: 0.75rem;
-        background: #f9fafb;
-        border-radius: 8px;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .metric-value {
+        font-family: var(--font-mono);
         font-size: 1.5rem;
         font-weight: 700;
-        color: #0e7490;
+        color: var(--accent);
         display: block;
     }
-    
+
     .metric-label {
+        font-family: var(--font-mono);
         font-size: 0.75rem;
-        color: var(--text-light);
+        color: var(--muted);
         text-transform: uppercase;
         letter-spacing: 0.5px;
     }
-    
+
     .report-highlights {
         margin-bottom: 1.5rem;
     }
-    
+
     .highlight-item {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         margin-bottom: 0.5rem;
         font-size: 0.9rem;
-        color: var(--text-color);
+        color: var(--text-soft);
     }
-    
+
     .highlight-icon {
-        color: #0e7490;
+        color: var(--accent);
         flex-shrink: 0;
     }
-    
+
     .view-report-link {
         display: block;
         text-align: center;
-        background: #0e7490;
-        color: white;
+        background: var(--accent);
+        color: var(--bg);
         padding: 0.75rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         text-decoration: none;
+        font-family: var(--font-mono);
         font-weight: 600;
-        transition: background 0.2s ease;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        transition: all 0.18s ease;
     }
-    
+
     .view-report-link:hover {
-        background: #5a5fbf;
-        color: white;
+        background: var(--accent-dim);
+        color: var(--bg);
     }
-    
+
     /* Filters */
     .filters-section {
-        background: white;
+        background: var(--surface);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.08);
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
     }
-    
+
     .filters-row {
         display: flex;
         gap: 1rem;
         flex-wrap: wrap;
         align-items: center;
     }
-    
+
     .filter-group {
         flex: 1;
         min-width: 200px;
     }
-    
+
     .filter-label {
         display: block;
         margin-bottom: 0.5rem;
+        font-family: var(--font-mono);
         font-size: 0.9rem;
         font-weight: 500;
-        color: var(--text-color);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        color: var(--muted);
     }
-    
+
     .filter-select {
         width: 100%;
         padding: 0.5rem 1rem;
-        border: 1px solid #e5e7eb;
-        border-radius: 8px;
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         font-size: 0.95rem;
-        background: white;
-        transition: border-color 0.2s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        transition: border-color 0.18s ease;
     }
-    
+
     .filter-select:focus {
         outline: none;
-        border-color: #0e7490;
+        border-color: var(--accent);
     }
-    
+
     /* Empty State */
     .empty-state {
         text-align: center;
         padding: 4rem 2rem;
-        color: var(--text-light);
+        color: var(--muted);
     }
-    
+
     .empty-state-icon {
         font-size: 3rem;
         margin-bottom: 1rem;
         opacity: 0.5;
     }
-    
+
     /* Responsive */
     @media (max-width: 768px) {
         .reports-hero h1 {
             font-size: 2rem;
         }
-        
+
         .reports-grid {
             grid-template-columns: 1fr;
         }
-        
+
         .month-header {
             flex-direction: column;
             gap: 1rem;
             align-items: flex-start;
         }
-        
+
         .filters-row {
             flex-direction: column;
         }
-        
+
         .filter-group {
             width: 100%;
         }
     }
-    
+
     /* Loading Animation */
     .loading {
         opacity: 0.6;
         pointer-events: none;
     }
-    
+
     .loading::after {
         content: '';
         position: absolute;
@@ -545,12 +603,12 @@
         width: 40px;
         height: 40px;
         margin: -20px 0 0 -20px;
-        border: 3px solid #f3f3f3;
-        border-top: 3px solid #0e7490;
+        border: 3px solid var(--border);
+        border-top: 3px solid var(--accent);
         border-radius: 50%;
         animation: spin 1s linear infinite;
     }
-    
+
     @keyframes spin {
         0% { transform: rotate(0deg); }
         100% { transform: rotate(360deg); }

--- a/templates/technique_detail.html
+++ b/templates/technique_detail.html
@@ -6,40 +6,42 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 <style>
     .technique-header {
-        background: linear-gradient(135deg, #4a5cbb 0%, #5d3b82 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
         margin-bottom: 3rem;
         text-align: center;
+        box-shadow: var(--shadow);
     }
-    
+
     .technique-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        background: linear-gradient(to right, #fff, #f0f0ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
+        color: var(--accent);
     }
-    
+
     .technique-info {
         font-size: 1.2rem;
-        color: #FFFFFF;
+        color: var(--text-soft);
         max-width: 800px;
         margin: 0 auto;
         line-height: 1.7;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.01em;
     }
-    /* Ensure all nested content inside the purple header description renders white
+    /* Ensure all nested content inside the header description renders readable
        even if global paragraph/link styles attempt to override it */
     .technique-header .technique-info,
     .technique-header .technique-info * {
-        color: #FFFFFF !important;
+        color: var(--text-soft) !important;
     }
-    
+
     .technique-tags {
         display: flex;
         justify-content: center;
@@ -47,17 +49,19 @@
         margin-top: 1.5rem;
         flex-wrap: wrap;
     }
-    
+
     .technique-tag {
         padding: 0.5rem 1rem;
         border-radius: 25px;
         font-size: 0.9rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        background: rgba(255, 255, 255, 0.2);
-        backdrop-filter: blur(10px);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        color: var(--text-soft);
     }
     
     .search-section {
@@ -68,18 +72,24 @@
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface-2);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
     
     .lures-container {
@@ -89,12 +99,19 @@
     }
     
     .lure-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
         padding: 2rem;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border-left: 4px solid #0e7490;
+        box-shadow: var(--shadow);
+        border-left: 3px solid var(--accent);
         position: relative;
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    .lure-item:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
     }
     
     .lure-header {
@@ -117,20 +134,21 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 1rem;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: var(--surface-3);
+        border: 1px solid var(--accent);
+        color: var(--accent);
         text-decoration: none;
-        border-radius: 6px;
+        border-radius: var(--border-radius);
         font-size: 0.9rem;
         font-weight: 500;
-        transition: all 0.2s ease;
-        box-shadow: 0 2px 4px rgba(102, 126, 234, 0.3);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
     }
-    
+
     .example-btn:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.4);
-        color: white;
+        transform: translateY(-2px);
+        background: var(--accent);
+        color: var(--bg);
         text-decoration: none;
     }
     
@@ -139,12 +157,14 @@
     }
     
     .lure-name {
+        font-family: var(--font-display);
         font-size: 1.5rem;
-        font-weight: 700;
-        color: #333;
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--text);
         margin: 0;
     }
-    
+
     .lure-link {
         color: inherit;
         text-decoration: none;
@@ -152,9 +172,9 @@
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .lure-link:hover {
-        color: #0e7490;
+        color: var(--accent);
     }
     
     .lure-capabilities {
@@ -168,24 +188,26 @@
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: var(--highlight);
+        border: 1px solid var(--border);
+        color: var(--accent);
     }
-    
+
     .lure-preamble {
-        background: rgba(102, 126, 234, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0e7490;
+        border-left: 3px solid var(--accent3);
     }
-    
+
     .lure-preamble p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -207,12 +229,12 @@
         position: relative;
         padding: 1rem 1rem 1rem 3.25rem;
         line-height: 1.6;
-        background: #f8fbff;
-        border: 1px solid #e6ecf2;
-        border-radius: 10px;
-        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        color: var(--text-soft);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
     }
-    
+
     .steps-list li::before {
         counter-increment: step;
         content: counter(step) ".";
@@ -223,46 +245,46 @@
         width: 28px;
         height: 28px;
         border-radius: 50%;
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: #fff;
+        background: var(--accent);
+        color: var(--bg);
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         justify-content: center;
-        font-weight: 800;
+        font-weight: 700;
         font-size: 0.95rem;
-        box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
     }
-    
+
     .steps-list li:first-child {
-        background: #fff7e6;
-        border-color: #ffe0b2;
+        background: var(--surface-3);
+        border-color: var(--accent4);
     }
     .steps-list li:first-child::before {
-        background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-        box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+        background: var(--accent4);
+        color: var(--bg);
     }
-    
+
     .lure-steps .steps-list li strong {
-        color: #1a1f36;
+        color: var(--accent);
         font-weight: 700;
-        background: #eef2ff;
-        border: 1px solid #c7d2fe;
+        font-family: var(--font-mono);
+        background: var(--highlight);
+        border: 1px solid var(--border);
         padding: 0.05rem 0.4rem;
-        border-radius: 6px;
-        box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+        border-radius: var(--border-radius);
     }
     
     .lure-epilogue {
-        background: rgba(118, 75, 162, 0.05);
+        background: var(--surface-2);
         padding: 1rem;
-        border-radius: 8px;
+        border-radius: var(--border-radius);
         margin-bottom: 1.5rem;
-        border-left: 3px solid #0f766e;
+        border-left: 3px solid var(--accent);
     }
-    
+
     .lure-epilogue p {
         margin: 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.6;
     }
     
@@ -273,110 +295,125 @@
     .lure-references h4, .lure-mitigations h4 {
         font-size: 1rem;
         font-weight: 600;
-        color: #333;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
         margin: 0 0 0.5rem 0;
     }
-    
+
     .references-list, .mitigations-list {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .references-list li, .mitigations-list li {
         padding: 0.25rem 0;
-        color: #555;
+        color: var(--text-soft);
         line-height: 1.5;
     }
-    
+
     .references-list a {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
     }
-    
+
     .references-list a:hover {
         text-decoration: underline;
     }
-    
+
     .lure-divider {
         border: none;
         height: 1px;
-        background: linear-gradient(90deg, transparent, #e1e5e9, transparent);
+        background: var(--border);
         margin: 1.5rem 0;
     }
-    
+
     .lure-contributor {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         flex-wrap: wrap;
     }
-    
+
     .contributor-label {
         font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 1px;
     }
-    
+
     .contributor-name {
         font-weight: 600;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .contributor-date {
-        color: #999;
+        color: var(--muted);
     }
-    
+
     .contributor-contacts {
         display: flex;
         gap: 0.5rem;
         margin-left: 0.5rem;
     }
-    
+
     .contact-link {
-        color: #0e7490;
+        color: var(--accent3);
         text-decoration: none;
         font-size: 1.1rem;
-        transition: color 0.3s ease;
+        transition: color 0.18s ease;
     }
-    
+
     .contact-link:hover {
-        color: #0f766e;
+        color: var(--accent);
     }
-    
+
     .back-link {
         display: inline-flex;
         align-items: center;
         gap: 0.5rem;
-        color: #0e7490;
+        color: var(--accent);
         text-decoration: none;
         font-weight: 600;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 1px;
         margin-bottom: 2rem;
-        transition: gap 0.2s ease;
+        transition: gap 0.18s ease;
     }
-    
+
     .back-link:hover {
         gap: 0.75rem;
     }
-    
+
     .warning-banner {
-        background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-        color: white;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent2);
+        color: var(--text);
         padding: 1.5rem;
-        border-radius: 12px;
+        border-radius: var(--border-radius);
         margin-bottom: 2rem;
         text-align: center;
-        box-shadow: 0 4px 20px rgba(255, 107, 107, 0.3);
+        box-shadow: var(--shadow);
     }
-    
+
     .warning-banner h3 {
         margin: 0 0 0.5rem 0;
         font-size: 1.2rem;
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: 1px;
+        color: var(--accent2);
     }
-    
+
     .warning-banner p {
         margin: 0;
-        opacity: 0.9;
+        color: var(--text-soft);
     }
     
     /* Responsive */
@@ -425,11 +462,11 @@
     <div class="technique-tags">
         <span class="technique-tag">
             {% if technique.platform == 'Windows' %}
-            <i class="fab fa-windows" style="color: #0078d4;"></i> Windows
+            <i class="fab fa-windows" style="color: var(--accent3);"></i> Windows
             {% elif technique.platform == 'Mac' %}
-            <i class="fab fa-apple" style="color: #000000;"></i> Mac
+            <i class="fab fa-apple" style="color: var(--text);"></i> Mac
             {% elif technique.platform == 'Linux' %}
-            <i class="fab fa-linux" style="color: #f47421;"></i> Linux
+            <i class="fab fa-linux" style="color: var(--accent4);"></i> Linux
             {% else %}
             {{ technique.platform }}
             {% endif %}
@@ -446,11 +483,11 @@
         {% for capability in technique.capabilities %}
         <span class="technique-tag">
             {% if capability == 'UAC' %}
-            <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+            <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
             {% elif capability == 'MOTW' %}
-            <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+            <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
             {% elif capability == 'File Explorer' %}
-            <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+            <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
             {% else %}
             {{ capability }}
             {% endif %}
@@ -487,11 +524,11 @@
                 {% for capability in lure.capabilities %}
                 <span class="capability-tag">
                     {% if capability == 'UAC' %}
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent3);"></i> UAC
                     {% elif capability == 'MOTW' %}
-                    <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
+                    <i class="fas fa-check-circle" style="color: var(--accent);"></i> MOTW
                     {% elif capability == 'File Explorer' %}
-                    <i class="fas fa-folder" style="color: #FFA726;"></i> File Explorer
+                    <i class="fas fa-folder" style="color: var(--accent4);"></i> File Explorer
                     {% else %}
                     {{ capability }}
                     {% endif %}

--- a/templates/technique_example.html
+++ b/templates/technique_example.html
@@ -3,10 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>{{ example_title }} - ClickFix Example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;600;700;800&family=Bebas+Neue&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        /* Standalone page — define the design tokens locally (no shared stylesheet). */
+        :root {
+            --bg: #0a0a0f; --surface: #0f0f1a; --surface-2: #13131f; --surface-3: #181826;
+            --border: #1e1e35; --accent: #00ff88; --accent-dim: #00cc6a;
+            --accent2: #ff3366; --accent3: #3d9eff; --accent4: #ffcc00;
+            --text: #e8e8f0; --text-soft: #c8c8d8; --muted: #6b6b8a;
+            --highlight: rgba(0,255,136,0.08); --border-radius: 4px;
+            --shadow: 0 12px 30px rgba(0,0,0,0.5);
+            --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+            --font-display: 'Bebas Neue', 'Inter', sans-serif;
+        }
         body {
-            font-family: Roboto, Helvetica, Arial, sans-serif;
-            background: #f5f5f5;
+            font-family: var(--font-sans);
+            background: var(--bg);
+            color: var(--text);
             margin: 0;
             padding: 0;
         }
@@ -15,23 +31,26 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #fff;
-            border: 1px solid #d3d3d3;
-            border-radius: 5px;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.08);
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--accent);
+            border-radius: var(--border-radius);
+            box-shadow: var(--shadow);
             padding: 32px 24px 24px 24px;
             text-align: center;
             min-width: 300px;
             max-width: 500px;
         }
         .example-title {
-            font-size: 20px;
-            font-weight: 500;
+            font-family: var(--font-display);
+            font-size: 24px;
+            font-weight: 400;
+            letter-spacing: 1.5px;
             margin-bottom: 10px;
-            color: #333;
+            color: var(--accent);
         }
         .example-desc {
-            color: #555;
+            color: var(--text-soft);
             font-size: 13px;
             margin-top: 10px;
             line-height: 1.4;
@@ -45,11 +64,12 @@
             padding: 16px 16px 16px 52px;
             margin: 10px 0;
             font-size: 14px;
-            color: #1a1f36;
-            background: #f8fbff;
-            border: 1px solid #e6ecf2;
-            border-radius: 10px;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+            color: var(--text-soft);
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--border-radius);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            transition: border-color 0.18s ease, transform 0.18s ease;
         }
         .step-number {
             position: absolute;
@@ -59,61 +79,74 @@
             width: 28px;
             height: 28px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
+            font-family: var(--font-mono);
             display: flex;
             align-items: center;
             justify-content: center;
             font-weight: 800;
             font-size: 14px;
-            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.35);
+            box-shadow: 0 2px 6px rgba(0, 255, 136, 0.25);
         }
         .step-content {
             display: inline;
         }
         /* Keycap-style emphasis for shortcuts and important words */
         .step-content strong {
-            color: #1a1f36;
+            color: var(--accent);
+            font-family: var(--font-mono);
             font-weight: 700;
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: var(--surface-3);
+            border: 1px solid var(--border);
             padding: 1px 6px;
-            border-radius: 6px;
-            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.06);
+            border-radius: var(--border-radius);
+            box-shadow: inset 0 -1px 0 rgba(0,0,0,0.4);
         }
         .step-content code {
-            background: #eef2ff;
-            border: 1px solid #c7d2fe;
+            background: #05050a;
+            color: var(--accent3);
+            font-family: var(--font-mono);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
             padding: 1px 6px;
-            border-radius: 6px;
+            border-radius: var(--border-radius);
         }
         .action-btn {
-            background: #1A73E8;
-            color: #fff;
+            background: var(--accent);
+            color: var(--bg);
             border: none;
-            border-radius: 3px;
+            border-radius: var(--border-radius);
             padding: 12px 32px;
+            font-family: var(--font-mono);
             font-size: 16px;
-            font-weight: 600;
+            font-weight: 700;
+            letter-spacing: 0.5px;
             cursor: pointer;
             margin-top: 18px;
-            transition: background 0.2s;
+            transition: background 0.18s, transform 0.18s;
+        }
+        .action-btn:hover {
+            transform: translateY(-2px);
         }
         .action-btn:active {
-            background: #155ab6;
+            background: var(--accent-dim);
         }
         .action-btn:disabled {
-            background: #ccc;
+            background: var(--muted);
+            color: var(--surface);
             cursor: not-allowed;
         }
         .copied-msg {
-            color: #388e3c;
+            color: var(--accent);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
         }
         .warning-msg {
-            color: #dc3545;
+            color: var(--accent2);
+            font-family: var(--font-mono);
             margin-top: 16px;
             font-size: 14px;
             display: none;
@@ -121,48 +154,54 @@
         .progress-bar {
             width: 100%;
             height: 4px;
-            background: #e9ecef;
+            background: var(--surface-3);
             border-radius: 2px;
             margin: 16px 0;
             overflow: hidden;
         }
         .progress-fill {
             height: 100%;
-            background: #28a745;
+            background: var(--accent);
             width: 0%;
             transition: width 0.3s ease;
         }
         .step-highlight {
-            background: #fff3cd;
-            border-color: #ffeaa7;
+            background: var(--highlight);
+            border-color: var(--accent4);
         }
         .step-completed {
-            background: #d4edda;
-            border-color: #c3e6cb;
+            background: var(--surface-3);
+            border-color: var(--accent);
         }
         .step-completed .step-number {
-            color: #28a745;
+            background: var(--surface-3);
+            color: var(--accent);
+            box-shadow: none;
         }
         /* Special treatment for the first step like ClickFix callout */
         #step-1 {
-            background: #fff7e6;
-            border-color: #ffe0b2;
+            background: var(--surface-2);
+            border-color: var(--accent4);
+            border-left: 3px solid var(--accent4);
         }
         #step-1 .step-number {
-            background: linear-gradient(135deg, #ffb84d 0%, #ff8a00 100%);
-            color: #fff;
-            box-shadow: 0 2px 6px rgba(255, 168, 0, 0.35);
+            background: var(--accent4);
+            color: var(--bg);
+            box-shadow: 0 2px 6px rgba(255, 204, 0, 0.25);
         }
         .back-link {
             position: absolute;
             top: 20px;
             left: 20px;
-            color: #0e7490;
+            color: var(--accent);
+            font-family: var(--font-mono);
             text-decoration: none;
             font-size: 14px;
             font-weight: 500;
+            transition: color 0.18s ease;
         }
         .back-link:hover {
+            color: var(--accent-dim);
             text-decoration: underline;
         }
         .disclaimer {
@@ -170,10 +209,14 @@
             bottom: 20px;
             left: 50%;
             transform: translateX(-50%);
+            font-family: var(--font-mono);
             font-size: 12px;
-            color: #6c757d;
+            color: var(--muted);
             text-align: center;
             max-width: 400px;
+        }
+        .disclaimer strong {
+            color: var(--accent4);
         }
     </style>
 </head>
@@ -199,8 +242,8 @@
         
         <div style="margin: 8px 0;">
             {% if example_commands %}
-            <label for="cmdSelect" style="font-size:13px;color:#555;">Example command:</label>
-            <select id="cmdSelect" style="margin-left:6px;padding:6px 8px;">
+            <label for="cmdSelect" style="font-size:13px;color:var(--text-soft);font-family:var(--font-mono);">Example command:</label>
+            <select id="cmdSelect" style="margin-left:6px;padding:6px 8px;background:var(--surface-3);color:var(--text);border:1px solid var(--border);border-radius:var(--border-radius);font-family:var(--font-mono);">
                 {% for cmd in example_commands %}
                 <option value="{{ cmd }}">{{ cmd }}</option>
                 {% endfor %}

--- a/templates/techniques.html
+++ b/templates/techniques.html
@@ -7,212 +7,240 @@
 <style>
     /* ClickFix Wiki Styling */
     .techniques-header {
-        background: linear-gradient(135deg, #0e7490 0%, #0f766e 100%);
-        color: white;
+        background: linear-gradient(135deg, var(--surface-2) 0%, var(--surface-3) 100%);
+        color: var(--text);
         padding: 3rem 2rem;
-        border-radius: 16px;
+        border-radius: var(--border-radius);
+        border: 1px solid var(--border);
+        border-top: 3px solid var(--accent);
+        box-shadow: var(--shadow);
         margin-bottom: 3rem;
         text-align: center;
     }
-    
+
     .techniques-title {
+        font-family: var(--font-display);
         font-size: 2.5rem;
-        font-weight: 800;
+        font-weight: 400;
+        letter-spacing: 2px;
         margin-bottom: 1rem;
-        color: white;
+        color: var(--accent);
     }
-    
+
     .techniques-subtitle {
         font-size: 1.2rem;
-        color: white;
+        color: var(--text-soft);
         max-width: 600px;
         margin: 0 auto;
         line-height: 1.6;
     }
-    /* Enforce white for any nested text in header/subtitle against global styles */
-    .techniques-header,
-    .techniques-header *,
-    .techniques-title,
-    .techniques-subtitle {
-        color: #FFFFFF !important;
+    /* Keep header copy readable against the dark surface */
+    .techniques-header .techniques-subtitle,
+    .techniques-header .techniques-subtitle * {
+        color: var(--text-soft) !important;
     }
-    
+    .techniques-header .techniques-title {
+        color: var(--accent) !important;
+    }
+
     .search-section {
         margin-bottom: 2rem;
     }
-    
+
     .search-box {
         width: 100%;
         max-width: 500px;
         padding: 1rem 1.5rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 50px;
         font-size: 1rem;
-        transition: all 0.3s ease;
-        background: white;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        font-family: var(--font-mono);
+        transition: all 0.18s ease;
+        background: var(--surface);
+        color: var(--text);
+        box-shadow: var(--shadow);
     }
-    
+
+    .search-box::placeholder {
+        color: var(--muted);
+    }
+
     .search-box:focus {
         outline: none;
-        border-color: #0e7490;
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--highlight);
     }
-    
+
     .filter-section {
         margin-bottom: 3rem;
     }
-    
+
     .filter-groups {
         display: flex;
         gap: 2rem;
         flex-wrap: wrap;
         justify-content: center;
     }
-    
+
     .filter-group {
-        background: white;
+        background: var(--surface);
         padding: 1.5rem;
-        border-radius: 12px;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+        border: 1px solid var(--border);
+        border-radius: var(--border-radius);
+        box-shadow: var(--shadow);
         min-width: 200px;
     }
-    
+
     .filter-group-title {
+        font-family: var(--font-mono);
         font-weight: 600;
         margin-bottom: 1rem;
-        color: #333;
+        color: var(--accent);
         font-size: 0.9rem;
         text-transform: uppercase;
         letter-spacing: 1px;
     }
-    
+
     .filter-tags {
         display: flex;
         flex-direction: column;
         gap: 0.5rem;
     }
-    
+
     .filter-tag {
         padding: 0.5rem 1rem;
-        border: 2px solid #e1e5e9;
+        border: 1px solid var(--border);
         border-radius: 25px;
+        background: var(--surface-2);
+        color: var(--text-soft);
         cursor: pointer;
-        transition: all 0.3s ease;
+        transition: all 0.18s ease;
         font-size: 0.9rem;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.5rem;
     }
-    
+
     .filter-tag:hover {
-        border-color: #0e7490;
-        background: rgba(102, 126, 234, 0.1);
+        border-color: var(--accent);
+        background: var(--highlight);
+        color: var(--text);
     }
-    
+
     .filter-tag.active {
-        background: #0e7490;
-        color: white;
-        border-color: #0e7490;
+        background: var(--accent);
+        color: var(--bg);
+        border-color: var(--accent);
     }
-    
+
     .tools-list {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
         gap: 1.5rem;
         margin-bottom: 3rem;
     }
-    
+
     .tool-item {
-        background: white;
-        border-radius: 12px;
+        background: var(--surface);
+        border-radius: var(--border-radius);
         padding: 1.5rem;
         text-decoration: none;
-        color: inherit;
-        transition: all 0.3s ease;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-        border: 1px solid transparent;
+        color: var(--text);
+        transition: all 0.18s ease;
+        box-shadow: var(--shadow);
+        border: 1px solid var(--border);
         position: relative;
         overflow: hidden;
     }
-    
+
     .tool-item::before {
         content: '';
         position: absolute;
         top: 0;
         left: 0;
         right: 0;
-        height: 4px;
-        background: linear-gradient(90deg, #0e7490, #0f766e);
+        height: 3px;
+        background: var(--accent);
         transform: scaleX(0);
-        transition: transform 0.3s ease;
+        transition: transform 0.18s ease;
     }
-    
+
     .tool-item:hover {
-        transform: translateY(-5px);
-        box-shadow: 0 8px 30px rgba(0,0,0,0.12);
-        border-color: #0e7490;
+        transform: translateY(-2px);
+        box-shadow: var(--shadow);
+        border-color: var(--accent);
     }
-    
+
     .tool-item:hover::before {
         transform: scaleX(1);
     }
-    
+
     .tool-title {
-        font-size: 1.25rem;
-        font-weight: 700;
+        font-family: var(--font-display);
+        font-size: 1.4rem;
+        font-weight: 400;
+        letter-spacing: 1px;
         margin-bottom: 1rem;
-        color: #333;
+        color: var(--text);
     }
-    
+
     .tool-tags {
         display: flex;
         flex-wrap: wrap;
         gap: 0.5rem;
         margin-bottom: 1rem;
     }
-    
+
     .tool-tag {
         padding: 0.25rem 0.75rem;
         border-radius: 15px;
         font-size: 0.8rem;
         font-weight: 500;
+        font-family: var(--font-mono);
         display: flex;
         align-items: center;
         gap: 0.25rem;
     }
-    
+
     .tool-tag.platform-tag {
-        background: rgba(102, 126, 234, 0.1);
-        color: #0e7490;
+        background: rgba(61, 158, 255, 0.12);
+        color: var(--accent3);
+        border: 1px solid rgba(61, 158, 255, 0.25);
     }
-    
+
     .tool-tag.presentation-tag {
-        background: rgba(118, 75, 162, 0.1);
-        color: #0f766e;
+        background: var(--highlight);
+        color: var(--accent);
+        border: 1px solid rgba(0, 255, 136, 0.25);
     }
-    
+
     .tool-tag.capability-tag {
-        background: rgba(76, 175, 80, 0.1);
-        color: #4CAF50;
+        background: rgba(255, 204, 0, 0.12);
+        color: var(--accent4);
+        border: 1px solid rgba(255, 204, 0, 0.25);
     }
-    
+
     .tool-lure-count {
         font-size: 0.9rem;
-        color: #666;
+        font-family: var(--font-mono);
+        color: var(--muted);
         font-weight: 500;
     }
-    
+
     .no-results {
         text-align: center;
         padding: 3rem;
-        color: #666;
+        color: var(--muted);
     }
-    
+
     .no-results h3 {
+        font-family: var(--font-display);
         font-size: 1.5rem;
+        font-weight: 400;
+        letter-spacing: 1px;
         margin-bottom: 0.5rem;
-        color: #333;
+        color: var(--text);
     }
     
     
@@ -263,7 +291,7 @@
                     <i class="fab fa-windows" style="color: #0078d4;"></i> Windows
                 </div>
                 <div class="filter-tag" data-platform="Mac" onclick="toggleFilter('platform', 'Mac', this)">
-                    <i class="fab fa-apple" style="color: #000000;"></i> Mac
+                    <i class="fab fa-apple" style="color: var(--text);"></i> Mac
                 </div>
                 <div class="filter-tag" data-platform="Linux" onclick="toggleFilter('platform', 'Linux', this)">
                     <i class="fab fa-linux" style="color: #f47421;"></i> Linux
@@ -287,7 +315,7 @@
             <div class="filter-group-title">Capabilities</div>
             <div class="filter-tags" id="capabilityTags">
                 <div class="filter-tag" data-capability="UAC" onclick="toggleFilter('capability', 'UAC', this)">
-                    <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                    <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 </div>
                 <div class="filter-tag" data-capability="MOTW" onclick="toggleFilter('capability', 'MOTW', this)">
                     <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
@@ -310,7 +338,7 @@
                 {% if technique.platform == 'Windows' %}
                 <i class="fab fa-windows" style="color: #0078d4;"></i> Windows
                 {% elif technique.platform == 'Mac' %}
-                <i class="fab fa-apple" style="color: #000000;"></i> Mac
+                <i class="fab fa-apple" style="color: var(--text);"></i> Mac
                 {% elif technique.platform == 'Linux' %}
                 <i class="fab fa-linux" style="color: #f47421;"></i> Linux
                 {% else %}
@@ -329,7 +357,7 @@
             {% for capability in technique.capabilities %}
             <span class="tool-tag capability-tag" data-capability="{{ capability }}">
                 {% if capability == 'UAC' %}
-                <i class="fas fa-shield-alt" style="color: #194360;"></i> UAC
+                <i class="fas fa-shield-alt" style="color: var(--accent2);"></i> UAC
                 {% elif capability == 'MOTW' %}
                 <i class="fas fa-check-circle" style="color: #4CAF50;"></i> MOTW
                 {% elif capability == 'File Explorer' %}

--- a/ui/threat_exports.py
+++ b/ui/threat_exports.py
@@ -344,7 +344,14 @@ def render_threat_exports_page():
     results = st.session_state.get("scan_results")
     precomputed = st.session_state.get("precomputed_intel")
 
-    # If no live scan, offer loading from nightly data
+    # On first visit with nothing loaded, auto-load the most recent nightly run
+    # so the page isn't empty. This pulls ALL three categories for that run.
+    if not results and not precomputed and not st.session_state.get("_intel_autoload_tried"):
+        st.session_state["_intel_autoload_tried"] = True
+        if _autoload_latest_run():
+            precomputed = st.session_state.get("precomputed_intel")
+
+    # If still nothing, offer an explicit picker.
     if not results and not precomputed:
         st.info(
             "No scan results in the current session. "
@@ -356,6 +363,12 @@ def render_threat_exports_page():
         precomputed = st.session_state.get("precomputed_intel")
         if not results and not precomputed:
             return
+    else:
+        # Data is loaded — still let the user switch to a different run.
+        with st.expander("Load a different nightly run", expanded=False):
+            _offer_nightly_load()
+            results = st.session_state.get("scan_results")
+            precomputed = st.session_state.get("precomputed_intel")
 
     # Section selector
     section = st.pills(
@@ -471,8 +484,106 @@ def _render_precomputed_table(rows, prefix):
     _render_export_buttons(rows, prefix)
 
 
+import re as _re
+
+# Per-category intel filenames look like: clipboard_commands_20260601_020619.json
+_INTEL_FILE_RE = _re.compile(
+    r"^(clipboard_commands|download_cradles|lure_variants)_(\d{8}_\d{6})\.json$"
+)
+
+
+def _format_run_ts(ts):
+    """20260601_020619 -> '2026-06-01 02:06:19' (falls back to the raw string)."""
+    try:
+        return datetime.strptime(ts, "%Y%m%d_%H%M%S").strftime("%Y-%m-%d %H:%M:%S")
+    except (ValueError, TypeError):
+        return ts
+
+
+def _discover_intel_runs(intel_dir):
+    """Group per-category intel files by run timestamp.
+
+    Returns an ordered dict-like list of (ts, {category_key: Path}) newest first.
+    """
+    runs = {}
+    if not intel_dir.exists():
+        return []
+    for p in intel_dir.glob("*.json"):
+        m = _INTEL_FILE_RE.match(p.name)
+        if not m:
+            continue
+        category, ts = m.group(1), m.group(2)
+        runs.setdefault(ts, {})[category] = p
+    return [(ts, runs[ts]) for ts in sorted(runs, reverse=True)]
+
+
+def _build_bundle_from_run(ts, files):
+    """Load all available category files for one run into a combined intel bundle."""
+    import json as _json
+
+    bundle = {
+        "timestamp": _format_run_ts(ts),
+        "date": _format_run_ts(ts),
+        "clipboard_commands": [],
+        "download_cradles": [],
+        "lure_variants": [],
+    }
+    sources = set()
+    intel_dir = None
+    for category, path in files.items():
+        intel_dir = path.parent
+        try:
+            rows = _json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            rows = []
+        if not isinstance(rows, list):
+            rows = []
+        bundle[category] = rows
+        for r in rows:
+            if isinstance(r, dict) and r.get("source_url"):
+                sources.add(r["source_url"])
+
+    # Prefer the true analyzed-URL count from the run's summary CSV if present.
+    total = len(sources)
+    summary = (intel_dir / f"threat_intel_summary_{ts}.csv") if intel_dir else None
+    if summary and summary.exists():
+        try:
+            import csv as _csv
+
+            with summary.open(encoding="utf-8") as fh:
+                total = max(total, sum(1 for _ in _csv.DictReader(fh)))
+        except Exception:
+            pass
+    bundle["total_urls_analyzed"] = total
+    return bundle
+
+
+def _autoload_latest_run():
+    """Auto-load the most recent nightly run (all 3 categories). Returns True on success."""
+    from pathlib import Path
+    import json as _json
+
+    # Combined file at repo root wins if it exists (local dev convenience).
+    latest_intel = Path("latest_threat_intel.json")
+    if latest_intel.exists():
+        try:
+            st.session_state["precomputed_intel"] = _json.loads(
+                latest_intel.read_text(encoding="utf-8")
+            )
+            return True
+        except Exception:
+            pass
+
+    runs = _discover_intel_runs(Path("nightly_reports") / "threat_intel")
+    if not runs:
+        return False
+    ts, files = runs[0]
+    st.session_state["precomputed_intel"] = _build_bundle_from_run(ts, files)
+    return True
+
+
 def _offer_nightly_load():
-    """Let users load from precomputed intel or a full nightly report."""
+    """Let users load a full nightly run (all categories) or a consolidated report."""
     from pathlib import Path
     import json as _json
 
@@ -480,63 +591,84 @@ def _offer_nightly_load():
     intel_dir = nightly_dir / "threat_intel"
     latest_intel = Path("latest_threat_intel.json")
     latest_report = Path("latest_consolidated_report.json")
+
+    # Each option: (label, kind, payload)
     options = []
 
-    # Prefer precomputed intel files (fastest)
     if latest_intel.exists():
-        options.append(("Latest threat intel (precomputed)", latest_intel, "intel"))
-    if intel_dir.exists():
-        for p in sorted(intel_dir.glob("*.json"), reverse=True)[:5]:
-            options.append((f"Intel: {p.name}", p, "intel_partial"))
+        options.append(("Latest threat intel (combined)", "intel_file", latest_intel))
 
-    # Fall back to full nightly reports
+    # Per-run bundles — every nightly run becomes ONE entry that loads all three
+    # categories together (clipboard + cradles + lures), fixing the empty-tab bug.
+    for ts, files in _discover_intel_runs(intel_dir)[:15]:
+        have = ", ".join(
+            short
+            for key, short in (
+                ("clipboard_commands", "clipboard"),
+                ("download_cradles", "cradles"),
+                ("lure_variants", "lures"),
+            )
+            if key in files
+        )
+        options.append(
+            (f"Nightly run {_format_run_ts(ts)}  ({have})", "intel_bundle", (ts, files))
+        )
+
+    # Full consolidated reports re-extract everything (slower, but complete objects).
     if latest_report.exists():
-        options.append(("Latest consolidated report (full)", latest_report, "report"))
+        options.append(("Latest consolidated report (full)", "report", latest_report))
     if nightly_dir.exists():
         for p in sorted(nightly_dir.glob("clickgrab_report_*.json"), reverse=True)[:10]:
-            options.append((p.name, p, "report"))
+            options.append((p.name, "report", p))
 
     if not options:
+        st.warning("No nightly data found in `nightly_reports/`.")
         return
 
     labels = [o[0] for o in options]
     choice = st.selectbox("Load from nightly data", ["(none)"] + labels)
-    if choice and choice != "(none)":
-        idx = labels.index(choice)
-        _, path, kind = options[idx]
-        try:
-            data = _json.loads(path.read_text(encoding="utf-8"))
+    if not choice or choice == "(none)":
+        return
 
-            if kind == "intel":
-                # Precomputed combined intel — load directly
-                st.session_state["precomputed_intel"] = data
+    _, kind, payload = options[labels.index(choice)]
+    try:
+        if kind == "intel_file":
+            data = _json.loads(payload.read_text(encoding="utf-8"))
+            st.session_state["precomputed_intel"] = data
+            # Clear any live/report results so the precomputed bundle is what renders.
+            st.session_state.pop("scan_results", None)
+            st.success(
+                f"Loaded combined intel ({data.get('date', 'unknown')}, "
+                f"{data.get('total_urls_analyzed', '?')} URLs).",
+                icon=":material/check_circle:",
+            )
+            st.rerun()
+        elif kind == "intel_bundle":
+            ts, files = payload
+            bundle = _build_bundle_from_run(ts, files)
+            st.session_state["precomputed_intel"] = bundle
+            # Clear any live/report results so the precomputed bundle is what renders.
+            st.session_state.pop("scan_results", None)
+            st.success(
+                f"Loaded nightly run {_format_run_ts(ts)} — "
+                f"{len(bundle['clipboard_commands'])} clipboard, "
+                f"{len(bundle['download_cradles'])} cradles, "
+                f"{len(bundle['lure_variants'])} lures.",
+                icon=":material/check_circle:",
+            )
+            st.rerun()
+        else:  # report
+            data = _json.loads(payload.read_text(encoding="utf-8"))
+            sites = data.get("sites", []) if isinstance(data, dict) else []
+            if sites:
+                st.session_state["scan_results"] = sites
+                st.session_state.pop("precomputed_intel", None)
                 st.success(
-                    f"Loaded precomputed intel from `{path.name}` "
-                    f"({data.get('date', 'unknown')}, {data.get('total_urls_analyzed', '?')} URLs).",
+                    f"Loaded {len(sites)} results from `{payload.name}`.",
                     icon=":material/check_circle:",
                 )
                 st.rerun()
-            elif kind == "intel_partial":
-                # Single-category intel file — wrap it
-                st.session_state["precomputed_intel"] = {
-                    "timestamp": "",
-                    "date": path.stem,
-                    "total_urls_analyzed": len({r.get("source_url") for r in data}) if isinstance(data, list) else 0,
-                    "clipboard_commands": data if "clipboard" in path.name else [],
-                    "download_cradles": data if "cradle" in path.name else [],
-                    "lure_variants": data if "lure" in path.name else [],
-                }
-                st.success(f"Loaded `{path.name}`.", icon=":material/check_circle:")
-                st.rerun()
             else:
-                # Full report — load sites into scan_results
-                sites = data.get("sites", [])
-                if sites:
-                    st.session_state["scan_results"] = sites
-                    st.success(
-                        f"Loaded {len(sites)} results from `{path.name}`.",
-                        icon=":material/check_circle:",
-                    )
-                    st.rerun()
-        except Exception as e:
-            st.error(f"Failed to load: {e}")
+                st.warning(f"`{payload.name}` has no `sites` to load.")
+    except Exception as e:
+        st.error(f"Failed to load: {e}")


### PR DESCRIPTION
## Summary

Fixes two Streamlit bugs, hardens scan stability, and gives the GitHub Pages site a full dark **hacker-terminal** redesign matching the BSides deck.

## 🐛 Streamlit fixes

**Clipboard Commands / Download Cradles tabs were empty** (even though the data existed)
- Root cause: each nightly run writes *three separate* per-category files (`clipboard_commands_*`, `download_cradles_*`, `lure_variants_*`), and the combined `latest_threat_intel.json` is **gitignored** so it never ships. The loader's partial path populated only the single file you selected, leaving the other two tabs empty.
- Fix: the loader now **groups the three files by run timestamp** into one bundle, **auto-loads the latest run** on first visit, and exposes a "Load a different nightly run" picker. Verified on the 2026-06-01 run: **87 clipboard + 22 cradles + 98 lures, 100 URLs** all load from a single selection.

**Live Scan froze on slow / unresponsive hosts**
- Root cause: `analyze_url` chained unbounded sequential fetches (~140s worst case per URL), and `requests` read-timeouts don't bound a host that trickles bytes.
- Fix: per-stage **wall-clock budgets** (external-JS 12s, redirect-follower 22s), a hard **75s per-URL backstop** in all three scan loops that reports a timeout and *advances* instead of freezing, and **streamed + deadline-bounded body reads** (slowloris-resistant). Tuple `(connect, read)` timeouts throughout.

**Stale-state fix:** switching nightly runs while live/report results were loaded rendered the old data — the intel branches now clear `scan_results`.

## 🎨 Website redesign

Full dark theme aligned to the deck: near-black `#0a0a0f` canvas, neon-green `#00ff88` accent, JetBrains Mono / Bebas Neue / Inter, grid + scanline background, gradient hero, terminal blocks, accent-edged cards, severity-colored threat scores. Reworked the shared `styles.css` + `base.html` + all 9 page templates; `docs/` and `public/` regenerated via `bin/build.py`.

## ✅ Verification

- Extraction results unchanged (29 indicators / score 361 on the bundled sample).
- All modules compile; Streamlit boots clean; every generated page renders dark with no leftover light colors.
- 3-lens adversarial review run; both real findings (stale-state + trickle-read) fixed.

## Notes
- `docs/` + `public/` churn (140 files) is the dark theme baked into every generated page — expected.
- Source of truth is `templates/` + `templates/css/styles.css`; the nightly job preserves the new look on rebuild.