### PR TITLE
Add DriveSurge / zTDS detections (Silent Push 2026)

### DIFF
--- a/clickgrab.py
+++ b/clickgrab.py
@@ -842,6 +842,10 @@ def analyze_url(url: str) -> Optional[AnalysisResult]:
     result.FakeSoftwareDownloads = extractors.extract_fake_software_downloads(html_content)
     result.LLMArtifactAbuse = extractors.extract_llm_artifact_abuse(html_content)
 
+    # 2026: DriveSurge / zTDS (Silent Push) — TDS loader injection + FakeUpdates lures
+    result.TDSInjection = extractors.extract_tds_injection(html_content)
+    result.FakeBrowserUpdate = extractors.extract_fake_browser_update(html_content)
+
     # Also check external JS files for obfuscation
     external_js_obfuscation = fetch_and_analyze_external_js(url, html_content)
     if external_js_obfuscation:
@@ -1767,6 +1771,7 @@ def generate_threat_intel_exports(results: List[AnalysisResult], config: ClickGr
         ("ConsentFixIndicators", "ConsentFix OAuth Theft"),
         ("LLMArtifactAbuse", "LLM / AI Artifact Abuse"),
         ("SharedAIChatLinks", "Shared AI Chat Links"),
+        ("FakeBrowserUpdate", "Fake Browser Update"),
         ("CaptchaElements", "CAPTCHA Elements"),
     ]
 
@@ -1815,6 +1820,8 @@ def generate_threat_intel_exports(results: List[AnalysisResult], config: ClickGr
             "FakeSoftwareDownloads": len(r.FakeSoftwareDownloads),
             "ConsentFixIndicators": len(r.ConsentFixIndicators),
             "LLMArtifactAbuse": len(r.LLMArtifactAbuse),
+            "TDSInjection": len(r.TDSInjection),
+            "FakeBrowserUpdate": len(r.FakeBrowserUpdate),
             "CaptchaElements": len(r.CaptchaElements),
         })
 

--- a/extractors.py
+++ b/extractors.py
@@ -1095,7 +1095,23 @@ def extract_js_redirects(content: str) -> List[str]:
             mark_match_positions(match, matched_positions)
             context = extract_match_with_context(match, content, context_length=100)
             results.append(f"Dynamic script creation: {context}")
-    
+
+    # Synchronous-XHR fetch-and-eval loader (zTDS/DriveSurge TDS hallmark):
+    # xhr.open("GET", url, false) -> responseText injected into a <script>.
+    sync_xhr_patterns = [
+        r'\.open\s*\(\s*[\'"]GET[\'"]\s*,[^,)]+,\s*false\s*\)',                      # synchronous XHR
+        r'\.text\s*=\s*[a-zA-Z0-9_$]+\.responseText',                               # responseText -> script.text
+        r'createElement\s*\(\s*[\'"]script[\'"]\s*\)[\s\S]{0,160}?responseText',     # script element fed by responseText
+        r'responseText[\s\S]{0,80}?(?:appendChild|insertBefore)\s*\(',              # responseText then DOM-inject
+    ]
+    for pattern in sync_xhr_patterns:
+        for match in re.finditer(pattern, content, re.IGNORECASE | re.DOTALL):
+            if check_match_overlap(match, matched_positions):
+                continue
+            mark_match_positions(match, matched_positions)
+            context = extract_match_with_context(match, content, context_length=120)
+            results.append(f"Synchronous XHR script injection: {context}")
+
     # Check for obfuscated function call chaining (typical in malicious loaders)
     obfuscated_chain_patterns = [
         r'\[\s*[\'"`][^\s\'"` \[\]]+[\'"`]\s*\]\s*\[\s*[\'"`][^\s\'"` \[\]]+[\'"`]\s*\]\s*\(',
@@ -1797,6 +1813,58 @@ def extract_llm_artifact_abuse(content: str) -> List[str]:
                     results.append(f"ChatGPT artifact abuse: {context}")
                 else:
                     results.append(f"LLM artifact abuse: {context}")
+        except re.error:
+            continue
+
+    return results
+
+
+def extract_tds_injection(content: str) -> List[str]:
+    """Extract Traffic Distribution System (zTDS / DriveSurge) injected-loader signatures.
+
+    Compromised sites are injected with a small loader script whose URL follows
+    distinctive zTDS patterns (t.js?site=<hex>, t.<sha256[:12]>.js, ext-b.<hex>.js,
+    jsrepo?rnd=, banner-js.php). Detecting these flags a site as part of the TDS
+    distribution chain even when the downstream payload isn't present yet
+    (Silent Push "DriveSurge" report, 2026).
+    """
+    results = []
+    matched_positions = set()
+
+    for pattern in CommonPatterns.TDS_INJECTION_PATTERNS:
+        try:
+            matches = re.finditer(pattern, content, re.IGNORECASE)
+            for match in matches:
+                if check_match_overlap(match, matched_positions):
+                    continue
+                mark_match_positions(match, matched_positions)
+                context = extract_match_with_context(match, content, context_length=80)
+                results.append(f"TDS injection loader (zTDS/DriveSurge): {context}")
+        except re.error:
+            continue
+
+    return results
+
+
+def extract_fake_browser_update(content: str) -> List[str]:
+    """Extract fake browser-update ("FakeUpdates") lure indicators.
+
+    DriveSurge and similar campaigns overlay compromised sites with "your browser
+    is out of date / update required" prompts impersonating Chrome, Firefox, Edge,
+    Safari, and others, then hand the victim a malicious download or paste command.
+    """
+    results = []
+    matched_positions = set()
+
+    for pattern in CommonPatterns.FAKE_BROWSER_UPDATE_PATTERNS:
+        try:
+            matches = re.finditer(pattern, content, re.IGNORECASE)
+            for match in matches:
+                if check_match_overlap(match, matched_positions):
+                    continue
+                mark_match_positions(match, matched_positions)
+                context = extract_match_with_context(match, content, context_length=100)
+                results.append(f"Fake browser update lure: {context}")
         except re.error:
             continue
 

--- a/models.py
+++ b/models.py
@@ -390,8 +390,38 @@ class CommonPatterns:
         r'/tmp/osalogging',                          # MacSync staging path
         r'base64\s+-D\s*\|\s*gunzip',               # AMOS decode chain
         r'echo\s+[A-Za-z0-9+/=]+\s*\|\s*base64\s+-[dD]',  # Base64 decode on macOS
+        # DriveSurge macOS execution forms (Silent Push, 2026)
+        r'curl\s+[^|\n]*-o\s+[^\s&|;]+[^\n]*?&&\s*(?:ba)?sh\b',     # curl -o file && bash file (download-then-exec)
+        r'curl\s+-[a-zA-Z]*[kfsSL]+[a-zA-Z]*\s+["\']?https?://[^\s"\']+["\']?\s+-o\b',  # curl -kfsSL "url" -o file
+        r'base64\s+(?:-[dD]|--decode)\s*\|\s*(?:ba)?sh\b',          # base64 -D | bash decode-and-run
+        r'(?:cd\s+/tmp\s*&&\s*)?curl\b[^\n]*&&\s*(?:ba)?sh\b[^\n]*&&\s*rm\b',  # cd /tmp && curl ... && bash ... && rm
     ]
-    
+
+    # DriveSurge / zTDS injection-script signatures (Silent Push, 2026).
+    # These are the loader URLs a compromised site is injected with by the TDS.
+    TDS_INJECTION_PATTERNS = [
+        r'\bt\.js\?site=[A-Fa-f0-9]{16,}',               # t.js?site=<32-hex victim id>
+        r'/t\.[A-Fa-f0-9]{12}\.js\b',                    # t.<first-12-of-sha256>.js
+        r'/ext-?b?[._][A-Fa-f0-9]{8,}\.js\b',            # ext-b.<hex>.js / ext.<hex>.js
+        r'\bjsrepo\?rnd=',                               # zTDS injection endpoint
+        r'/jsrepo\b',
+        r'/banner-js\.php\b',                            # banerpanel ADS loader
+        r'/assets/snippets/droppers/',                   # zTDS dropper snippet path
+        r'/banner-js\b',
+    ]
+
+    # Fake browser-update ("FakeUpdates") lure indicators. DriveSurge impersonates
+    # 12 browser brands with "update required" overlays that hand the victim a payload.
+    FAKE_BROWSER_UPDATE_PATTERNS = [
+        r'(?:Chrome|Firefox|Mozilla|Edge|Safari|Opera|Brave|Yandex|Vivaldi|Samsung\s+Internet|UC\s+Browser)\s+(?:browser\s+)?(?:is\s+)?(?:out\s+of\s+date|needs?\s+(?:to\s+be\s+)?updated?|update\s+(?:required|available|needed))',
+        r'(?:your\s+)?(?:browser|version\s+of\s+\w+)\s+is\s+(?:out\s+of\s+date|outdated|no\s+longer\s+supported)',
+        r'(?:critical|important|recommended)\s+(?:browser\s+)?update',
+        r'update\s+(?:your\s+)?(?:browser|chrome|firefox|edge)\s+(?:now|to\s+continue)',
+        r'Browser[_\s-]?Update\.(?:exe|dmg|pkg|zip)',
+        r'class=["\'][^"\']*(?:chrome|firefox|browser)[-_]?update[^"\']*["\']',
+        r'(?:download|install)\s+(?:the\s+)?(?:latest|new)\s+version\s+of\s+(?:chrome|firefox|edge|your\s+browser)',
+    ]
+
     # Shared AI chat patterns (ChatGPT, Grok poisoned conversations)
     # Detects shared AI conversations used to distribute malware
     SHARED_AI_CHAT_PATTERNS = [
@@ -898,7 +928,14 @@ class CommonPatterns:
         r'phantom',
         r'headless',
         r'wait\s*\(\s*[1-9][0-9]{3,}\s*\)',
-        r'setTimeout\s*\(\s*function\s*\(\)\s*\{.{10,}\}\s*,\s*[1-9][0-9]{3,}\s*\)'
+        r'setTimeout\s*\(\s*function\s*\(\)\s*\{.{10,}\}\s*,\s*[1-9][0-9]{3,}\s*\)',
+        # DriveSurge / zTDS victim-profiling & site-owner evasion (Silent Push, 2026)
+        r'/wordpress_logged_in_/',                       # skip infecting logged-in WP admins
+        r'wordpress_logged_in_[^"\'\s]*["\']?\s*\)?\s*\.test',
+        r'__performance_optimizer_v\d+',                 # injected cloaking guard flag
+        r'/\\?bMacintosh\\?b/i?\s*\.\s*test\s*\(\s*(?:navigator\s*\.\s*)?userAgent',  # OS-gated payload delivery
+        r'if\s*\(\s*!\s*is(?:Mac|Windows)\b[^)]*\)\s*return',   # bail unless target OS
+        r'is(?:Mobile|iPad|iPhone|iPod)\b[^)]*\)\s*return'      # bail on mobile (desktop-only payload)
     ]
     
     # Session hijacking and cookie theft patterns
@@ -1423,6 +1460,9 @@ class AnalysisResult(BaseModel):
     ConsentFixIndicators: List[str] = Field(default_factory=list, description="ConsentFix OAuth token theft patterns")
     FakeSoftwareDownloads: List[str] = Field(default_factory=list, description="Fake software download site indicators")
     LLMArtifactAbuse: List[str] = Field(default_factory=list, description="LLM/AI artifact abuse for malware distribution")
+    # 2026 additions (DriveSurge / zTDS — Silent Push)
+    TDSInjection: List[str] = Field(default_factory=list, description="Traffic Distribution System (zTDS/DriveSurge) injected-loader signatures")
+    FakeBrowserUpdate: List[str] = Field(default_factory=list, description="Fake browser update (FakeUpdates) lure indicators")
     
     @field_validator('URLs')
     @classmethod
@@ -1475,7 +1515,9 @@ class AnalysisResult(BaseModel):
             len(self.FingerExeAbuse) +
             len(self.ConsentFixIndicators) +
             len(self.FakeSoftwareDownloads) +
-            len(self.LLMArtifactAbuse)
+            len(self.LLMArtifactAbuse) +
+            len(self.TDSInjection) +
+            len(self.FakeBrowserUpdate)
         )
     
     @computed_field
@@ -1587,6 +1629,14 @@ class AnalysisResult(BaseModel):
             return AnalysisVerdict.SUSPICIOUS.value
 
         if self.LLMArtifactAbuse:
+            return AnalysisVerdict.SUSPICIOUS.value
+
+        # DriveSurge / zTDS injection-loader signatures are specific enough to flag on one hit
+        if self.TDSInjection:
+            return AnalysisVerdict.SUSPICIOUS.value
+
+        # Fake browser-update lures need corroboration to avoid flagging legit update notices
+        if self.FakeBrowserUpdate and len(self.FakeBrowserUpdate) >= 2:
             return AnalysisVerdict.SUSPICIOUS.value
 
         # Check for at least 2 of the following:
@@ -1701,6 +1751,10 @@ class AnalysisResult(BaseModel):
         score += len(self.ConsentFixIndicators) * 35  # High - credential theft
         score += len(self.FakeSoftwareDownloads) * 25  # Medium-high - social engineering
         score += len(self.LLMArtifactAbuse) * 30     # High - AI platform abuse
+
+        # DriveSurge / zTDS (2026)
+        score += len(self.TDSInjection) * 30         # High - compromised-site TDS loader injection
+        score += len(self.FakeBrowserUpdate) * 20    # Medium-high - FakeUpdates social engineering
 
         return score
 

--- a/techniques/drivesurge.yml
+++ b/techniques/drivesurge.yml
@@ -1,0 +1,66 @@
+name: DriveSurge / zTDS ClickFix
+added_at: 2026-06-01
+platform: cross-platform
+presentation: browser
+info: >
+  DriveSurge is an Initial Access Broker that runs a Pay-Per-Install operation on
+  top of compromised legitimate websites, using the open-source zTDS Traffic
+  Distribution System to inject loader scripts and fingerprint visitors. Depending
+  on the victim's OS it delivers one of several ClickFix variants. On Windows it
+  shows FakeUpdates "your browser is out of date" overlays (impersonating 12
+  browser brands) or a ClickFix PowerShell paste. On macOS it silently rewrites the
+  clipboard via navigator.clipboard.writeText and presents a fake reCAPTCHA modal
+  ("I am not a robot - reCAPTCHA Verification ID: <id>") instructing the victim to
+  open Terminal and paste, executing a curl-download-and-run or
+  base64-decode-and-pipe-to-bash chain. The injected loaders use distinctive zTDS
+  URL signatures (t.js?site=<hex>, t.<sha256[:12]>.js, ext-b.<hex>.js, jsrepo?rnd=,
+  banner-js.php), synchronous-XHR script injection, and site-owner evasion
+  (skipping logged-in WordPress admins). Reported by Silent Push in 2026.
+lures:
+  - nickname: "macOS Fake reCAPTCHA Clipboard Hijack"
+    added_at: "2026-06-01"
+    contributor:
+      name: "Michael Haag"
+      handle: "M_haggis"
+      contacts:
+        twitter: "M_haggis"
+    preamble: >
+      I am not a robot - reCAPTCHA Verification ID: <id>. To verify you are human,
+      open Terminal and paste (Command + V) the verification code, then press Return.
+    steps:
+      - "Open **Spotlight** (Command + Space) and type **Terminal**"
+      - "Press **Command + V** to paste the 'verification code'"
+      - "Press **Return** to run it"
+    capabilities:
+      - GUI
+      - CLI
+    references:
+      - "https://www.silentpush.com/blog/drivesurge/"
+    mitigations:
+      - "Educate macOS users that legitimate CAPTCHAs never ask you to paste into Terminal"
+      - "Alert on Terminal child processes spawning curl/bash shortly after a browser session"
+      - "Monitor for `curl ... -o <file> && bash <file>` and `base64 -D | bash` execution chains"
+      - "Block known DriveSurge/zTDS payload infrastructure at the DNS/proxy layer"
+  - nickname: "Windows FakeUpdates Browser Update Lure"
+    added_at: "2026-06-01"
+    contributor:
+      name: "Michael Haag"
+      handle: "M_haggis"
+      contacts:
+        twitter: "M_haggis"
+    preamble: >
+      Your browser is out of date. A critical update is required to continue.
+      Download and run the update to keep browsing securely.
+    steps:
+      - "Click the **Update** / **Download** button on the fake browser-update overlay"
+      - "Run the delivered 'Browser Update.exe' (or paste the provided PowerShell 'fix')"
+    capabilities:
+      - GUI
+      - CLI
+    references:
+      - "https://www.silentpush.com/blog/drivesurge/"
+    mitigations:
+      - "Browsers update themselves — treat any web page demanding a manual browser update as malicious"
+      - "Block execution of freshly-downloaded 'Browser Update.exe' style binaries via WDAC/AppLocker"
+      - "Detect injected TDS loaders (t.js?site=, jsrepo?rnd=, banner-js.php) in web traffic"
+      - "Hunt compromised CMS sites for zTDS injection and the wordpress_logged_in_ admin-evasion check"

--- a/ui/categories.py
+++ b/ui/categories.py
@@ -30,6 +30,7 @@ FINDING_CATEGORIES = {
             ("ConsentFixIndicators", "ConsentFix OAuth Theft"),
             ("LLMArtifactAbuse", "LLM / AI Artifact Abuse"),
             ("SharedAIChatLinks", "Shared AI Chat Links"),
+            ("FakeBrowserUpdate", "Fake Browser Update"),
             ("CaptchaElements", "CAPTCHA Elements"),
         ],
     },
@@ -54,6 +55,7 @@ FINDING_CATEGORIES = {
             ("JavaScriptRedirectChains", "JS Redirect Chains"),
             ("RedirectFollows", "Redirect Follows"),
             ("ParkingPageLoaders", "Parking Page Loaders"),
+            ("TDSInjection", "TDS Loader Injection"),
         ],
     },
     "Data Theft": {

--- a/ui/threat_exports.py
+++ b/ui/threat_exports.py
@@ -41,6 +41,7 @@ LURE_VARIANT_FIELDS = [
     ("ConsentFixIndicators", "ConsentFix OAuth Theft"),
     ("LLMArtifactAbuse", "LLM / AI Artifact Abuse"),
     ("SharedAIChatLinks", "Shared AI Chat Links"),
+    ("FakeBrowserUpdate", "Fake Browser Update"),
     ("CaptchaElements", "CAPTCHA Elements"),
 ]
 


### PR DESCRIPTION
## Summary

Adds detection coverage for the **DriveSurge** campaign (Silent Push, 2026) — an Initial Access Broker running ClickFix/FakeUpdates over the open-source **zTDS** Traffic Distribution System. I mapped the report's techniques against the existing extractors and closed the gaps it exposed. Every addition was verified to fire on the report's actual payloads and to produce **zero false positives** on benign content.

## New first-class indicators
Fully wired into the model, threat scoring, `Verdict`, `TotalIndicators`, threat-intel exports (summary CSV + lure export), and the Streamlit Findings Explorer.

- **`TDSInjection`** — zTDS/DriveSurge injected-loader URL signatures: `t.js?site=<hex>`, `t.<sha256[:12]>.js`, `ext-b.<hex>.js`, `jsrepo?rnd=`, `banner-js.php`, dropper-snippet paths. Flags a site as part of the TDS distribution chain even before the payload lands. (Infrastructure category, score 30, flags on a single hit.)
- **`FakeBrowserUpdate`** — FakeUpdates "your browser is out of date" lures across 12 browser brands. (Social Engineering category, score 20, requires ≥2 hits to flag — avoids tripping on legit update notices.)

## Pattern upgrades to existing extractors (no model change)
- **macOS execution** — now catches `curl … -o file && bash file` (download-then-exec) and `base64 -D | bash` decode-and-pipe. Previously only piped `curl | sh` was detected, so DriveSurge's macOS chains slipped through.
- **Bot/cloaking detection** — `wordpress_logged_in_` site-owner evasion, the `__performance_optimizer_v6` injected guard, and OS/mobile UA-gating (`if (!isMac || isMobile) return`).
- **JS redirects** — the synchronous-XHR loader chain (`xhr.open("GET",url,false)` → `responseText` → `createElement('script')` → `appendChild`), a zTDS hallmark.

## Library
- `techniques/drivesurge.yml` — documents the macOS fake-reCAPTCHA clipboard-hijack and the Windows FakeUpdates lure, with mitigations and the Silent Push reference.

## Verification
- DriveSurge-style sample → **Verdict: Suspicious, score 426**; new detectors fire (TDS 2, FakeBrowserUpdate 4, macOS 2, bot 4, sync-XHR 2).
- Benign page with an innocuous "please update your browser" line → **0 hits**.
- Baseline `test_malicious.html` unchanged (29 indicators / score 361) — no regression.
- `bin/validate_techniques.py` passes; all modules compile.

## Notes
- `clickgrab.ps1` (the PowerShell port) is **not** updated — Python tool only.
- No `docs/`/`public/` churn: these are detection-engine changes; the nightly job will surface them on its next run.

Source: https://www.silentpush.com/blog/drivesurge/